### PR TITLE
Optionally group bundles by day for upload

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,7 @@ type S3Config struct {
 	Bucket  string
 	Region  string
 	Timeout duration
+	S3Only  bool
 }
 
 type RedshiftConfig struct {

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	CheckInterval   duration
 	TmpDir          string
 	ListExportLimit int
+	GroupFilesByDay bool
 
 	// for debug only; can point to localhost
 	ExportURL string

--- a/example-config.toml
+++ b/example-config.toml
@@ -4,6 +4,7 @@ BackoffStepsMax = 8
 CheckInterval = "30m"
 TmpDir = "/tmp"
 Warehouse="redshift"
+GroupFilesByDay = false
 
 [s3]
 # bucket that will be used to stage files into Redshift

--- a/example-config.toml
+++ b/example-config.toml
@@ -12,6 +12,8 @@ Bucket = ""
 Region = "us-east-2"
 # timeout for copying export files from the local machine to S3
 Timeout = "5m"
+# upload data file only (i.e. skip load to Redshift)?
+S3Only = true
 
 [redshift]
 User = "<your user>"

--- a/main.go
+++ b/main.go
@@ -62,8 +62,18 @@ func ProcessExportsSince(wh warehouse.Warehouse, since time.Time) (int, error) {
 		return 0, err
 	}
 
-	for _, e := range exports {
-		log.Printf("Processing bundle %d (start: %s, end: %s)", e.ID, e.Start, e.Stop)
+	if conf.GroupFilesByDay {
+		return LoadFilesGrouped(wh, fs, exports)
+	} else {
+		return LoadFilesSingly(wh, fs, exports)
+	}
+}
+
+// LoadFilesSingly iterates over the list of available export files and processes them one by one, until an error
+// occurs, or until they are all processed.
+func LoadFilesSingly(wh warehouse.Warehouse, fs *fullstory.Client, exports []fullstory.ExportMeta) (int, error) {
+	for i, e := range exports {
+		log.Printf("Processing bundle %d (start: %s, end: %s)", e.ID, e.Start.UTC(), e.Stop.UTC())
 		filename := filepath.Join(conf.TmpDir, fmt.Sprintf("%d.csv", e.ID))
 		mark := time.Now()
 		outfile, err := os.Create(filename)
@@ -75,57 +85,17 @@ func ProcessExportsSince(wh warehouse.Warehouse, since time.Time) (int, error) {
 		defer outfile.Close()
 		csvOut := csv.NewWriter(outfile)
 
-		stream, err := fs.ExportData(e.ID)
+		recordCount, err := WriteBundleToCSV(fs, e.ID, csvOut, wh)
 		if err != nil {
-			log.Printf("Failed to fetch bundle %d: %s", e.ID, err)
 			return 0, err
 		}
-		defer stream.Close()
-
-		gzstream, err := gzip.NewReader(stream)
-		if err != nil {
-			log.Printf("Failed gzip reader: %s", err)
-			return 0, err
-		}
-
-		decoder := json.NewDecoder(gzstream)
-		decoder.UseNumber()
-
-		// skip array open delimiter
-		if _, err := decoder.Token(); err != nil {
-			log.Printf("Failed json decode of array token: %s", err)
-			return 0, err
-		}
-
-		var recordCount int
-		for decoder.More() {
-			var r Record
-			if err := decoder.Decode(&r); err != nil {
-				log.Printf("failed json decode of record: %s", err)
-				return 0, err
-			}
-			line, err := TransformExportJsonRecord(wh, r)
-			if err != nil {
-				log.Printf("Failed object transform, bundle %d; skipping record. %s", e.ID, err)
-				continue
-			}
-			csvOut.Write(line)
-			recordCount++
-		}
-
-		if _, err := decoder.Token(); err != nil {
-			log.Printf("Failed json decode of array token: %s", err)
-			return 0, err
-		}
-
-		csvOut.Flush()
 
 		if err := wh.LoadToWarehouse(filename); err != nil {
 			log.Printf("Failed to load file '%s' to warehouse: %s", filename, err)
 			return 0, err
 		}
 
-		if err := wh.SaveSyncPoint(e.ID, e.Stop); err != nil {
+		if err := wh.SaveSyncPoints(exports[i : i+1]); err != nil {
 			// If we've already copied in the data but fail to save the sync point, we're
 			// still okay - the next call to LastSyncPoint() will see that there are export
 			// records beyond the sync point and remove them - ie, we will reprocess the
@@ -140,6 +110,110 @@ func ProcessExportsSince(wh warehouse.Warehouse, since time.Time) (int, error) {
 
 	// return how many files were processed
 	return len(exports), nil
+}
+
+// LoadFilesGrouped creates a single intermediate CSV file for all the export bundles on a given day.  It assumes the
+// day to be processed is the day from the first export bundle's Start value.  When all the bundles with that same day
+// have been written to the CSV file, it is loaded to the warehouse, and the function quits without attempting to
+// process remaining bundles (they'll get picked up on the next call to ProcessExportsSince)
+func LoadFilesGrouped(wh warehouse.Warehouse, fs *fullstory.Client, exports []fullstory.ExportMeta) (int, error) {
+	if len(exports) == 0 {
+		return 0, nil
+	}
+
+	log.Printf("Creating group file starting with bundle %d (start: %s)", exports[0].ID, exports[0].Start.UTC())
+	filename := filepath.Join(conf.TmpDir, fmt.Sprintf("%d-%s.csv", exports[0].ID, exports[0].Start.UTC().Format("20060102")))
+	mark := time.Now()
+	outfile, err := os.Create(filename)
+	if err != nil {
+		log.Printf("Failed to create tmp file: %s", err)
+		return 0, err
+	}
+	defer os.Remove(filename)
+	defer outfile.Close()
+	csvOut := csv.NewWriter(outfile)
+
+	var processedBundles []fullstory.ExportMeta
+	var totalRecords int
+	groupDay := exports[0].Start.UTC().Truncate(24 * time.Hour)
+	for _, e := range exports {
+		if !groupDay.Equal(e.Start.UTC().Truncate(24 * time.Hour)) {
+			break
+		}
+
+		recordCount, err := WriteBundleToCSV(fs, e.ID, csvOut, wh)
+		if err != nil {
+			return 0, err
+		}
+
+		log.Printf("Wrote bundle %d (%d records, start: %s, stop: %s)", e.ID, recordCount, e.Start.UTC(), e.Stop.UTC())
+		totalRecords += recordCount
+		processedBundles = append(processedBundles, e)
+	}
+
+	if err := wh.LoadToWarehouse(filename); err != nil {
+		log.Printf("Failed to load file '%s' to warehouse: %s", filename, err)
+		return 0, err
+	}
+
+	if err := wh.SaveSyncPoints(processedBundles); err != nil {
+		log.Printf("Failed to save sync points for bundles ending with %d: %s", processedBundles[len(processedBundles)].ID, err)
+		return 0, err
+	}
+
+	log.Printf("Processing of %d bundles (%d records) took %s", len(processedBundles), totalRecords,
+		time.Since(mark))
+
+	// return how many files were processed
+	return len(processedBundles), nil
+}
+
+func WriteBundleToCSV(fs *fullstory.Client, bundleID int, csvOut *csv.Writer, wh warehouse.Warehouse) (numRecords int, err error) {
+	stream, err := fs.ExportData(bundleID)
+	if err != nil {
+		log.Printf("Failed to fetch bundle %d: %s", bundleID, err)
+		return 0, err
+	}
+	defer stream.Close()
+
+	gzstream, err := gzip.NewReader(stream)
+	if err != nil {
+		log.Printf("Failed gzip reader: %s", err)
+		return 0, err
+	}
+
+	decoder := json.NewDecoder(gzstream)
+	decoder.UseNumber()
+
+	// skip array open delimiter
+	if _, err := decoder.Token(); err != nil {
+		log.Printf("Failed json decode of array token: %s", err)
+		return 0, err
+	}
+
+	var recordCount int
+	for decoder.More() {
+		var r Record
+		if err := decoder.Decode(&r); err != nil {
+			log.Printf("failed json decode of record: %s", err)
+			return recordCount, err
+		}
+		line, err := TransformExportJsonRecord(wh, r)
+		if err != nil {
+			log.Printf("Failed object transform, bundle %d; skipping record. %s", bundleID, err)
+			continue
+		}
+		csvOut.Write(line)
+		recordCount++
+	}
+
+	if _, err := decoder.Token(); err != nil {
+		log.Printf("Failed json decode of array token: %s", err)
+		return recordCount, err
+	}
+
+	csvOut.Flush()
+	return recordCount, nil
 }
 
 func BackoffOnError(err error) bool {

--- a/warehouse/redshift.go
+++ b/warehouse/redshift.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/lib/pq"
+	"github.com/nishanths/fullstory"
 )
 
 type Redshift struct {
@@ -36,9 +37,9 @@ var (
 
 func NewRedshift(c *config.Config) *Redshift {
 	return &Redshift{
-		conf: c,
+		conf:         c,
 		exportSchema: ExportTableSchema(RedshiftTypeMap),
-		syncSchema: SyncTableSchema(RedshiftTypeMap),
+		syncSchema:   SyncTableSchema(RedshiftTypeMap),
 	}
 }
 
@@ -185,7 +186,7 @@ func (rs *Redshift) CreateSyncTable() error {
 	return err
 }
 
-func (rs *Redshift) SaveSyncPoint(id int, stop time.Time) error {
+func (rs *Redshift) SaveSyncPoints(bundles []fullstory.ExportMeta) error {
 	var err error
 	rs.conn, err = rs.MakeRedshfitConnection()
 	if err != nil {
@@ -194,10 +195,15 @@ func (rs *Redshift) SaveSyncPoint(id int, stop time.Time) error {
 	}
 	defer rs.conn.Close()
 
-	insert := fmt.Sprintf("insert into %s values (%d, '%s', '%s')",
-		rs.conf.Redshift.SyncTable, id, time.Now().Format(time.RFC3339), stop.Format(time.RFC3339))
-	_, err = rs.conn.Exec(insert)
-	return err
+	for _, e := range bundles {
+		insert := fmt.Sprintf("insert into %s values (%d, '%s', '%s')",
+			rs.conf.Redshift.SyncTable, e.ID, time.Now().Format(time.RFC3339), e.Stop.Format(time.RFC3339))
+		if _, err := rs.conn.Exec(insert); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (rs *Redshift) DeleteExportRecordsAfter(end time.Time) error {

--- a/warehouse/redshift.go
+++ b/warehouse/redshift.go
@@ -186,7 +186,7 @@ func (rs *Redshift) CreateSyncTable() error {
 	return err
 }
 
-func (rs *Redshift) SaveSyncPoints(bundles []fullstory.ExportMeta) error {
+func (rs *Redshift) SaveSyncPoints(bundles ...fullstory.ExportMeta) error {
 	var err error
 	rs.conn, err = rs.MakeRedshfitConnection()
 	if err != nil {

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -1,11 +1,15 @@
 package warehouse
 
-import "time"
+import (
+	"time"
+
+	"github.com/nishanths/fullstory"
+)
 
 type Warehouse interface {
 	ExportTableSchema() Schema
 	LastSyncPoint() (time.Time, error)
-	SaveSyncPoint(id int, stop time.Time) error
+	SaveSyncPoints(bundles []fullstory.ExportMeta) error
 	LoadToWarehouse(filename string) error
 	ValueToString(val interface{}, f Field) string
 }

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -9,7 +9,7 @@ import (
 type Warehouse interface {
 	ExportTableSchema() Schema
 	LastSyncPoint() (time.Time, error)
-	SaveSyncPoints(bundles []fullstory.ExportMeta) error
+	SaveSyncPoints(bundles ...fullstory.ExportMeta) error
 	LoadToWarehouse(filename string) error
 	ValueToString(val interface{}, f Field) string
 }


### PR DESCRIPTION
This PR adds a new flag called `GroupFilesByDay` which, when true, will cause Hauser to combine all the bundles for the same day into a single CSV file before loading the file into the warehouse.  Grouping the bundles together provides two benefits, particularly when there are many small bundles:

1.  Loading data for many days at once is much faster, as the number of round trips from Hauser to the warehouse is greatly reduced.
2.  For BigQuery specifically, there is a quota of 1000 load jobs per day.  It is not uncommon for larger clients to generate bundles every 30 minutes, which means 48 bundles per day.  Thus you cannot load more than 20-21 days of data before you reach the limit.  Grouping the bundles allows you to load much more data before using up the quota.