### PR TITLE
Scrub carriage return characters from data values

### DIFF
--- a/warehouse/bigquery.go
+++ b/warehouse/bigquery.go
@@ -178,6 +178,7 @@ func (bq *BigQuery) ValueToString(val interface{}, isTime bool) string {
 	}
 
 	s = strings.Replace(s, "\n", " ", -1)
+	s = strings.Replace(s, "\r", " ", -1)
 	s = strings.Replace(s, "\x00", "", -1)
 
 	return s

--- a/warehouse/redshift.go
+++ b/warehouse/redshift.go
@@ -54,6 +54,7 @@ func (rs *Redshift) ValueToString(val interface{}, isTime bool) string {
 	}
 
 	s = strings.Replace(s, "\n", " ", -1)
+	s = strings.Replace(s, "\r", " ", -1)
 	s = strings.Replace(s, "\x00", "", -1)
 
 	if len(s) >= rs.conf.Redshift.VarCharMax {


### PR DESCRIPTION
Google BigQuery was refusing to load some CSV files due to the existence of carriage return characters (ascii 13) in the files.  This change replaces those characters with a space, similar to what we already do with line feeds.