### PR TITLE
Dockerized Hauser for Google BigQuery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.7
+RUN apt update && \
+	 apt install -y gettext-base
+
+COPY server-conf/ /server-conf/
+RUN mkdir -p /go/src/github.com/fullstorydev/hauser/ && \
+	 cp /server-conf/entry.sh /usr/local/bin/entry.sh
+
+ADD . /go/src/github.com/fullstorydev/hauser/
+WORKDIR /go/src/github.com/fullstorydev/hauser/
+RUN go build -o /usr/local/bin/hauser .
+ENTRYPOINT ["entry.sh"]

--- a/server-conf/config.toml.tmpl
+++ b/server-conf/config.toml.tmpl
@@ -1,0 +1,17 @@
+FsApiToken = "$FULLSTORY_API_TOKEN"
+Backoff = "30s"
+BackoffStepsMax = 8
+CheckInterval = "30m"
+TmpDir = "/tmp"
+Warehouse="bigquery"
+GroupFilesByDay = false
+
+[gcs]
+Bucket = "$GCS_BUCKET"
+GCSOnly = false
+
+[bigquery]
+Project = "$BIGQUERY_PROJECT"
+Dataset = "$BIGQUERY_DATASET"
+ExportTable = "$BIGQUERY_EXPORT_TABLE"
+SyncTable = "$BIGQUERY_SYNC_TABLE"

--- a/server-conf/entry.sh
+++ b/server-conf/entry.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+echo "Generating config..."
+echo $GOOGLE_KEY_JSON > /server-conf/google_key.json
+export GOOGLE_APPLICATION_CREDENTIALS=/server-conf/google_key.json
+
+envsubst < /server-conf/config.toml.tmpl > /server-conf/config.toml
+# cat /server-conf/config.toml
+# cat /server-conf/google_key.json
+
+echo "Starting hauser..."
+hauser -c /server-conf/config.toml


### PR DESCRIPTION
This doesn't work for Amazon RedShift yet, but should serve as a good jumping-off point to get it started

Executable container is available at `quay.io/jewlr/hauser`