### PR TITLE
Add support for schema changes to BigQuery

### DIFF
--- a/warehouse/bigquery.go
+++ b/warehouse/bigquery.go
@@ -225,7 +225,7 @@ func (bq *BigQuery) GetMissingFields(hauserSchema, bqSchema bigquery.Schema) []*
 	bqSchemaMap := makeSchemaMap(bqSchema)
 	var missingFields []*bigquery.FieldSchema
 	for _, f := range hauserSchema {
-		if _, ok := bqSchemaMap[f.Name]; !ok {
+		if _, ok := bqSchemaMap[strings.ToLower(f.Name)]; !ok {
 			missingFields = append(missingFields, f)
 		}
 	}
@@ -246,7 +246,7 @@ func (bq *BigQuery) AppendToSchema(schema bigquery.Schema, missingFields []*bigq
 func makeSchemaMap(schema bigquery.Schema) map[string]struct{} {
 	schemaMap := make(map[string]struct{})
 	for _, f := range schema {
-		schemaMap[f.Name] = struct{}{}
+		schemaMap[strings.ToLower(f.Name)] = struct{}{}
 	}
 	return schemaMap
 }

--- a/warehouse/bigquery_test.go
+++ b/warehouse/bigquery_test.go
@@ -1,0 +1,121 @@
+package warehouse
+
+import (
+	"testing"
+
+	"cloud.google.com/go/bigquery"
+)
+
+var _ Warehouse = &BigQuery{}
+
+func TestGetMissingFields(t *testing.T) {
+	wh := &BigQuery{}
+
+	requiredField1 := bigquery.FieldSchema {
+		Name: "RequiredField1",
+	}
+	requiredField2 := bigquery.FieldSchema {
+		Name: "RequiredField2",
+	}
+	dummyField := bigquery.FieldSchema {
+		Name: "DummyField",
+	}
+
+	hauserSchema := bigquery.Schema([]*bigquery.FieldSchema {
+		&requiredField1,
+		&requiredField2,
+	})
+
+	var testCases = []struct {
+		hauserSchema	bigquery.Schema
+		tableSchema		bigquery.Schema
+		missingFields	int
+	} {
+		{
+			hauserSchema,
+			bigquery.Schema([]*bigquery.FieldSchema {
+			}),
+			2,
+		},
+		{
+			hauserSchema,
+			bigquery.Schema([]*bigquery.FieldSchema {
+				&dummyField,
+			}),
+			2,
+		},
+		{
+			hauserSchema,
+			bigquery.Schema([]*bigquery.FieldSchema {
+				&requiredField2,
+				&dummyField,
+			}),
+			1,
+		},
+		{
+			hauserSchema,
+			bigquery.Schema([]*bigquery.FieldSchema {
+				&requiredField1,
+				&requiredField2,
+			}),
+			0,
+		},
+	}
+
+	for _, testCase := range testCases {
+		if got := wh.GetMissingFields(testCase.hauserSchema, testCase.tableSchema); len(got) != testCase.missingFields {
+			t.Errorf("Expected %d missing fields, got %d", testCase.missingFields, len(got))
+		}
+	}
+}
+
+// The purpose of this test is to make sure we mark Required to false for all the fields we add
+func TestAppendToSchema(t *testing.T) {
+	wh := &BigQuery{}
+
+	requiredField1 := bigquery.FieldSchema {
+		Name: "RequiredField1",
+		Required: true,
+	}
+	requiredField2 := bigquery.FieldSchema {
+		Name: "RequiredField2",
+		Required: false,
+	}
+
+	hauserSchema := bigquery.Schema([]*bigquery.FieldSchema {})
+
+	var testCases = []struct {
+		hauserSchema	bigquery.Schema
+		requiredFields	[]*bigquery.FieldSchema
+	} {
+		{
+			hauserSchema,
+			[]*bigquery.FieldSchema {},
+		},
+		{
+			hauserSchema,
+			[]*bigquery.FieldSchema {
+				&requiredField1,
+			},
+		},
+		{
+			hauserSchema,
+			[]*bigquery.FieldSchema {
+				&requiredField1,
+				&requiredField2,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		schema := wh.AppendToSchema(testCase.hauserSchema, testCase.requiredFields)
+		if len(schema) != len(testCase.requiredFields) {
+			t.Errorf("Expected %d fields to be appended, got %d", len(testCase.requiredFields), len(schema))
+		}
+		for _, f := range schema {
+			if f.Required {
+				t.Errorf("Expected all fields to have 'Required'=false got true for field %s", f.Name)
+			}
+		}
+	}
+}

--- a/warehouse/bigquery_test.go
+++ b/warehouse/bigquery_test.go
@@ -14,6 +14,9 @@ func TestGetMissingFields(t *testing.T) {
 	requiredField1 := bigquery.FieldSchema {
 		Name: "RequiredField1",
 	}
+	requiredField1Lowercase := bigquery.FieldSchema {
+		Name: "requiredfield1",
+	}
 	requiredField2 := bigquery.FieldSchema {
 		Name: "RequiredField2",
 	}
@@ -56,6 +59,14 @@ func TestGetMissingFields(t *testing.T) {
 			hauserSchema,
 			bigquery.Schema([]*bigquery.FieldSchema {
 				&requiredField1,
+				&requiredField2,
+			}),
+			0,
+		},
+		{
+			hauserSchema,
+			bigquery.Schema([]*bigquery.FieldSchema {
+				&requiredField1Lowercase,
 				&requiredField2,
 			}),
 			0,

--- a/warehouse/bigquery_test.go
+++ b/warehouse/bigquery_test.go
@@ -82,24 +82,24 @@ func TestAppendToSchema(t *testing.T) {
 		Required: false,
 	}
 
-	hauserSchema := bigquery.Schema([]*bigquery.FieldSchema {})
+	emptySchema := bigquery.Schema([]*bigquery.FieldSchema {})
 
 	var testCases = []struct {
 		hauserSchema	bigquery.Schema
 		requiredFields	[]*bigquery.FieldSchema
 	} {
 		{
-			hauserSchema,
+			emptySchema,
 			[]*bigquery.FieldSchema {},
 		},
 		{
-			hauserSchema,
+			emptySchema,
 			[]*bigquery.FieldSchema {
 				&requiredField1,
 			},
 		},
 		{
-			hauserSchema,
+			emptySchema,
 			[]*bigquery.FieldSchema {
 				&requiredField1,
 				&requiredField2,


### PR DESCRIPTION
This PR adds BigQuery support for schema changes. If hauser fields are not present in the existing export table in the specified dataset, we now add them and make sure all hauser fields are also present on any existing dataset table.

This is part (2) of a larger arc of work which will -
(1) [Add support for changing export schema on Redshift](https://github.com/fullstorydev/hauser/pull/14)
(2) Add support for changing export schema on BigQuery
(3) [Add new fields to the export](https://github.com/fullstorydev/hauser/pull/17)

