### PR TITLE
Start Hauser Setup

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+app=hauser
+container=c8-cluster
+environ=prod
+force=false
+port=8080
+project=c8-platform
+region=us-central1
+version=1.0.0
+zone=us-central1-a
+
+while [ $# -gt "0" ];
+do
+  case $1 in
+    -a=*|--app=*) app="${1#*=}";;
+    -c=*|--container=*) container="${1#*=}";;
+    -e=*|--env=*) environ="${1#*=}";;
+    -f=*|--force=*) force="${1#*=}";;
+    -o=*|--port=*) port="${1#*=}";;
+    -p=*|--project=*) project="${1#*=}";;
+    -r=*|--region=*) region="${1#*=}";;
+    -v=*|--version=*) version="${1#*=}";;
+    -z=*|--zone=*) zone="${1#*=}";;
+  esac
+  shift
+done;
+
+echo "Building "$app":"$version" in "$project"-"$environ"("$region"/"$zone"):"$container
+
+# ensure we're looking at the right cluster
+gcloud config set project $project-$environ
+gcloud config set compute/region $region
+gcloud config set compute/zone $zone
+gcloud container clusters get-credentials $container
+
+# replace existing local image
+docker rmi -f gcr.io/$project-$environ/$app:$version
+docker build --build-arg port=$port --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" -t gcr.io/$project-$environ/$app:$version .
+
+# replace existing remote image
+gcloud container images delete -q --force-delete-tags gcr.io/$project-$environ/$app:$version
+gcloud docker -- push gcr.io/$project-$environ/$app:$version
+
+echo "Build complete, deploying with "$replicas" copies to "$environ"."
+
+# redeploy
+if [ $force = "true" ]
+then
+  kubectl delete service $app
+  kubectl delete deployment $app
+fi
+
+cat deploy.yaml | \
+sed -e "s/\${app}/"$app"/" \
+ -e "s/\${environ}/"$environ"/" \
+ -e "s/\${port}/"$port"/" \
+ -e "s/\${project}/"$project"/" \
+ -e "s/\${region}/"$region"/" \
+ -e "s/\${version}/"$version"/" \
+  | kubectl apply -f -

--- a/c8-config.toml
+++ b/c8-config.toml
@@ -3,7 +3,7 @@ Backoff = "30s"
 BackoffStepsMax = 8
 CheckInterval = "30m"
 TmpDir = "/tmp"
-Warehouse="redshift"
+Warehouse="bigquery"
 GroupFilesByDay = false
 
 [s3]
@@ -35,7 +35,7 @@ Bucket = "<your bucket>"
 GCSOnly = false
 
 [bigquery]
-Project = "<your project>"
+Project = "c8-analytics"
 Dataset = "<your dataset>"
 ExportTable = "<your export table>"
 SyncTable = "<your sync table>"

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -1,0 +1,32 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: ${app}
+spec:
+  revisionHistoryLimit: 2
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ${app}
+    spec:
+      nodeSelector:
+        name: platform-api
+      containers:
+        - image: gcr.io/${project}-${environ}/${app}:${version}
+          imagePullPolicy: Always
+          name: ${app}
+          ports:
+          - containerPort: 8888
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8888
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8888
+            initialDelaySeconds: 30
+            timeoutSeconds: 5


### PR DESCRIPTION
#### JIRA TICKET:
https://codeeightco.atlassian.net/browse/BI-12

#### Description:
Code8 has decided to use FullStory for front-end analytics. They collect data around user interactions with our service. We need to ETL that data into our own system for analysis. FullStory has created an open-source tool called `hauser` that periodically calls their [Data Export API](https://help.fullstory.com/develop-rest/data-export-api) and dumps that data into a specified sink, in our case BigQuery. This PR attempts to set up hauser to deploy as a pod to our kubernetes cluster. I have added the `build.sh` and `deploy.yaml` files in accordance with how we currently deploy to kubernetes.

The directions for setting up `hauser` can be found in the README here - https://github.com/fullstorydev/hauser
