### PR TITLE
Add config options that let users upload json files only

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -30,10 +30,11 @@ type Config struct {
 }
 
 type S3Config struct {
-	Bucket  string
-	Region  string
-	Timeout duration
-	S3Only  bool
+	Bucket              string
+	Region              string
+	Timeout             duration
+	S3Only              bool
+	UploadAsJSONToS3    bool
 }
 
 type RedshiftConfig struct {
@@ -49,8 +50,9 @@ type RedshiftConfig struct {
 }
 
 type GCSConfig struct {
-	Bucket  string
-	GCSOnly bool
+	Bucket              string
+	GCSOnly             bool
+	UploadAsJSONToGCS   bool
 }
 
 type BigQueryConfig struct {

--- a/example-config.toml
+++ b/example-config.toml
@@ -13,8 +13,10 @@ Bucket = ""
 Region = "us-east-2"
 # timeout for copying export files from the local machine to S3
 Timeout = "5m"
-# upload data file only (i.e. skip load to Redshift)?
+# upload data file only (i.e. skip load to Redshift)
 S3Only = true
+# If S3Only is set to true, you can choose to upload the export file as Json instead of Csv
+UploadAsJSONToS3 = false
 
 [redshift]
 User = "<your user>"
@@ -32,7 +34,10 @@ VarCharMax = 65535
 
 [gcs]
 Bucket = "<your bucket>"
+# upload data file only (i.e. skip load to Bigquery)
 GCSOnly = false
+# If GCSOnly is set to true, you can choose to upload the export file as Json instead of Csv
+UploadAsJSONToGCS = false
 
 [bigquery]
 Project = "<your project>"


### PR DESCRIPTION
Separate PR for creating new properties, that lets users upload files as JSON instead of CSV if they are not loading into the warehouse and want to query the files directly. 