### PR TITLE
Reduce db calls to get Export Table columns

### DIFF
--- a/main.go
+++ b/main.go
@@ -305,6 +305,8 @@ func main() {
 		log.Fatal(err)
 	}
 
+	// Note(aneesh): We SHOULD fetch the table columns ONLY after the call to EnsureCompatibleExportTable.
+	// The EnsureCompatibleExportTable function potentially alters the schema of the export table in the client warehouse.
 	tableColumns := wh.GetExportTableColumns()
 	for {
 		lastSyncedRecord, err := wh.LastSyncPoint()

--- a/main.go
+++ b/main.go
@@ -305,7 +305,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// Note(aneesh): We SHOULD fetch the table columns ONLY after the call to EnsureCompatibleExportTable.
+	// NB: We SHOULD fetch the table columns ONLY after the call to EnsureCompatibleExportTable.
 	// The EnsureCompatibleExportTable function potentially alters the schema of the export table in the client warehouse.
 	tableColumns := wh.GetExportTableColumns()
 	for {


### PR DESCRIPTION
Previously we were querying the warehouse export table, getting the export table columns, for every record we inserted. This commit makes it so we only query the table columns once after any potential schema updates.