### PR TITLE
Respect 'Retry-After' property if defined in the 429 response

### DIFF
--- a/main.go
+++ b/main.go
@@ -220,19 +220,20 @@ func getExportData(fs *fullstory.Client, bundleID int) (fullstory.ExportData, er
 		}
 
 		log.Printf("Failed to fetch export data for Bundle %d", bundleID)
+		retryAfterDuration := defaultRetryAfterDuration
 		if statusError, ok := err.(fullstory.StatusError); ok {
 			// If the status code is NOT 429 and the code is below 500 we will not attempt to retry
 			if statusError.StatusCode != http.StatusTooManyRequests && statusError.StatusCode < 500 {
 				break
 			}
 
-			retryAfterDuration := defaultRetryAfterDuration
 			if retryAfter, err := strconv.Atoi(statusError.RetryAfter); err == nil {
 				retryAfterDuration = time.Duration(retryAfter) * time.Second
 			}
-			log.Printf("Attempt #%d failed. Retrying after %s\n", r, retryAfterDuration)
-			time.Sleep(retryAfterDuration)
 		}
+
+		log.Printf("Attempt #%d failed. Retrying after %s\n", r, retryAfterDuration)
+		time.Sleep(retryAfterDuration)
 	}
 	return nil, fmt.Errorf("Unable to fetch export data. Tried %d times.", maxAttempts)
 }

--- a/main.go
+++ b/main.go
@@ -27,10 +27,10 @@ var (
 )
 
 const (
-	// Maximum number of times Hauser will attempt to retry each request made to fullstory
+	// Maximum number of times Hauser will attempt to retry each request made to FullStory
 	maxAttempts int = 3
 
-	// Default duration Hauser will wait before retrying after getting a 429 response, if no retry-after is specified in the response. Arbitrarily set to 10s.
+	// Default duration Hauser will wait before retrying a 429 or 5xx response. If Retry-After is specified, uses that instead. Default arbitrarily set to 10s.
 	defaultRetryAfterDuration time.Duration = time.Duration(10) * time.Second
 )
 

--- a/vendor/github.com/nishanths/fullstory/client.go
+++ b/vendor/github.com/nishanths/fullstory/client.go
@@ -17,11 +17,12 @@ var _ error = StatusError{}
 type StatusError struct {
 	Status     string
 	StatusCode int
+	RetryAfter string
 	Body       io.Reader
 }
 
 func (e StatusError) Error() string {
-	return fmt.Sprintf("fullstory: response error: %s", e.Status)
+	return fmt.Sprintf("fullstory: response error: Status:%s, StatusCode:%d, RetryAfter:%s", e.Status, e.StatusCode, e.RetryAfter)
 }
 
 // Client represents a HTTP client for making requests to the FullStory API.
@@ -53,7 +54,7 @@ func NewClient(apiToken string) *Client {
 //
 // If the error is nil, the caller is responsible for closing the returned data.
 func (c *Client) doReq(req *http.Request) (io.ReadCloser, error) {
-	req.Header.Set("Authorization", "Basic "+c.APIToken)
+	req.Header.Set("Authorization", "Basic " + c.APIToken)
 	req.Header.Set("Accept-encoding", "*")
 
 	resp, err := c.HTTPClient.Do(req)
@@ -65,11 +66,17 @@ func (c *Client) doReq(req *http.Request) (io.ReadCloser, error) {
 		defer resp.Body.Close()
 		b := &bytes.Buffer{}
 		io.Copy(b, resp.Body) // Ignore error.
-		return nil, StatusError{
+		statusError := StatusError {
 			Body:       b,
 			Status:     resp.Status,
 			StatusCode: resp.StatusCode,
 		}
+
+		if resp.StatusCode == http.StatusTooManyRequests {
+			statusError.RetryAfter = resp.Header.Get("Retry-After")
+		}
+
+		return nil, statusError
 	}
 
 	return resp.Body, nil

--- a/vendor/github.com/nishanths/fullstory/client.go
+++ b/vendor/github.com/nishanths/fullstory/client.go
@@ -66,17 +66,12 @@ func (c *Client) doReq(req *http.Request) (io.ReadCloser, error) {
 		defer resp.Body.Close()
 		b := &bytes.Buffer{}
 		io.Copy(b, resp.Body) // Ignore error.
-		statusError := StatusError {
+		return nil, StatusError{
 			Body:       b,
 			Status:     resp.Status,
+			RetryAfter: resp.Header.Get("Retry-After"),
 			StatusCode: resp.StatusCode,
 		}
-
-		if resp.StatusCode == http.StatusTooManyRequests {
-			statusError.RetryAfter = resp.Header.Get("Retry-After")
-		}
-
-		return nil, statusError
 	}
 
 	return resp.Body, nil


### PR DESCRIPTION
This change makes it so if we encounter a 429 response when fetching export data, we parse the Retry-After property and respect the specified wait time before retrying.

A few constants were arbitrarily defined - # of retries and default wait Retry-After time if none is specified in the response. If you think there is value in having these constants sourced from the config, happy to move them there.

Changes were made to the vendor/github.com/nishanths/fullstory package. If the changes are acceptable here, I will make corresponding changes in the vendor package and reconcile.

