### PR TITLE
Fix custom var handling in JSON to CSV conversion

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,8 +50,8 @@ func TransformExportJSONRecord(wh warehouse.Warehouse, tableColumns []string, re
 	// Map of CustomVars
 	customVarsMap := make(map[string]interface{})
 	for key, val := range rec {
-		if field, ok := bundleFieldsMap[key]; !ok {
-			customVarsMap[field.Name] = val
+		if _, ok := bundleFieldsMap[key]; !ok {
+			customVarsMap[key] = val
 		}
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -4,9 +4,12 @@ import (
 	"testing"
 	"net/http"
 	"time"
-	
+
 	"github.com/pkg/errors"
 	"github.com/nishanths/fullstory"
+	"github.com/fullstorydev/hauser/warehouse"
+	"fmt"
+	"encoding/json"
 )
 
 func TestGetRetryInfo(t *testing.T) {
@@ -51,4 +54,113 @@ func TestGetRetryInfo(t *testing.T) {
 			t.Errorf("expected %v, got %v for doRetry on test case %d", tc.expRetryAfter, retryAfter, i)
 		}
 	}
+}
+
+func TestTransformExportJSONRecord(t *testing.T) {
+	testCases := []struct {
+		tableColumns []string
+		rec map[string]interface{}
+		expResult []string
+	} {
+		// no custom vars
+		{
+			tableColumns: []string{"eventtargettext", "pageduration", "customvars"},
+			rec: map[string]interface{} {
+				"EventTargetText": "Heyo!",
+				"PageDuration": 42,
+			},
+			expResult: []string{"Heyo!", "42", `{}`},
+		},
+		// two custom vars
+		{
+			tableColumns: []string{"eventtargettext", "pageduration", "customvars"},
+			rec: map[string]interface{} {
+				"EventTargetText": "Heyo!",
+				"PageDuration": 42,
+				"custom_str": "Heyo again!",
+				"custom_num": 42,
+			},
+			expResult: []string{"Heyo!", "42", `{"custom_str":"Heyo again!","custom_num":42}`},
+		},
+		// missing column value for pageduration
+		{
+			tableColumns: []string{"eventtargettext", "pageduration", "customvars"},
+			rec: map[string]interface{} {
+				"EventTargetText": "Heyo!",
+			},
+			expResult: []string{"Heyo!", "", `{}`},
+		},
+		// additional columns in target table that are not in the export
+		{
+			tableColumns: []string{"eventtargettext", "pageduration", "customvars", "randomcolumnnotinexport"},
+			rec: map[string]interface{} {
+				"EventTargetText": "Heyo!",
+				"PageDuration": 42,
+			},
+			expResult: []string{"Heyo!", "42", `{}`, ""},
+		},
+	}
+
+	for i, tc := range testCases {
+		wh := StubWarehouse{}
+		result, err := TransformExportJSONRecord(&wh, tc.tableColumns, tc.rec)
+		if err != nil {
+			t.Errorf("Unexpected err %s on test case %d", err, i)
+			continue
+		}
+		if len(result) != len(tc.expResult) {
+			t.Errorf("Incorrect length of result; expected %d, got %d on test case %d", len(result), len(tc.expResult), i)
+			continue
+		}
+		for j := range tc.expResult {
+			if !compareTransformedStrings(t, tc.expResult[j], result[j]) {
+				t.Errorf("Result mismatch; expected %s, got %s on test case %d, item %d", tc.expResult[j], result[j], i, j)
+			}
+		}
+	}
+}
+
+func compareTransformedStrings(t *testing.T, str1, str2 string) bool {
+	if str1 == str2 {
+		return true
+	}
+	if len(str1) > 0 && str1[0] == '{' {
+		return compareJSONStrings(t, str2, str2)
+	}
+	return false
+}
+
+func compareJSONStrings(t *testing.T, str1, str2 string) bool {
+	// decode JSON
+	var m1,m2 interface{}
+	if err := json.Unmarshal([]byte(str1), &m1); err != nil {
+		t.Fatalf("Could not unmarshal JSON string: %s", str1)
+	}
+	if err := json.Unmarshal([]byte(str2), &m2); err != nil {
+		t.Fatalf("Could not unmarshal JSON string: %s", str2)
+	}
+	decoded1 := m1.(map[string]interface{})
+	decoded2 := m2.(map[string]interface{})
+
+	// compare decoded maps
+	for key1, value1 := range decoded1 {
+		value2, ok := decoded2[key1]
+		if !ok || value1 != value2 {
+			return false
+		}
+	}
+	return true
+}
+
+type StubWarehouse struct {
+	warehouse.Warehouse
+}
+
+func (sw *StubWarehouse) ValueToString(val interface{}, isTime bool) string {
+	s := fmt.Sprintf("%v", val)
+	if isTime {
+		t, _ := time.Parse(time.RFC3339Nano, s)
+		return t.Format(time.RFC3339)
+	}
+	return s
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,15 +1,15 @@
 package main
 
 import (
-	"testing"
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"testing"
 	"time"
 
-	"github.com/pkg/errors"
-	"github.com/nishanths/fullstory"
 	"github.com/fullstorydev/hauser/warehouse"
-	"fmt"
-	"encoding/json"
+	"github.com/nishanths/fullstory"
+	"github.com/pkg/errors"
 )
 
 func TestGetRetryInfo(t *testing.T) {
@@ -59,33 +59,33 @@ func TestGetRetryInfo(t *testing.T) {
 func TestTransformExportJSONRecord(t *testing.T) {
 	testCases := []struct {
 		tableColumns []string
-		rec map[string]interface{}
-		expResult []string
-	} {
+		rec          map[string]interface{}
+		expResult    []string
+	}{
 		// no custom vars
 		{
 			tableColumns: []string{"eventtargettext", "pageduration", "customvars"},
-			rec: map[string]interface{} {
+			rec: map[string]interface{}{
 				"EventTargetText": "Heyo!",
-				"PageDuration": 42,
+				"PageDuration":    42,
 			},
 			expResult: []string{"Heyo!", "42", `{}`},
 		},
 		// two custom vars
 		{
 			tableColumns: []string{"eventtargettext", "pageduration", "customvars"},
-			rec: map[string]interface{} {
+			rec: map[string]interface{}{
 				"EventTargetText": "Heyo!",
-				"PageDuration": 42,
-				"custom_str": "Heyo again!",
-				"custom_num": 42,
+				"PageDuration":    42,
+				"custom_str":      "Heyo again!",
+				"custom_num":      42,
 			},
 			expResult: []string{"Heyo!", "42", `{"custom_str":"Heyo again!","custom_num":42}`},
 		},
 		// missing column value for pageduration
 		{
 			tableColumns: []string{"eventtargettext", "pageduration", "customvars"},
-			rec: map[string]interface{} {
+			rec: map[string]interface{}{
 				"EventTargetText": "Heyo!",
 			},
 			expResult: []string{"Heyo!", "", `{}`},
@@ -93,9 +93,9 @@ func TestTransformExportJSONRecord(t *testing.T) {
 		// additional columns in target table that are not in the export
 		{
 			tableColumns: []string{"eventtargettext", "pageduration", "customvars", "randomcolumnnotinexport"},
-			rec: map[string]interface{} {
+			rec: map[string]interface{}{
 				"EventTargetText": "Heyo!",
-				"PageDuration": 42,
+				"PageDuration":    42,
 			},
 			expResult: []string{"Heyo!", "42", `{}`, ""},
 		},
@@ -132,7 +132,7 @@ func compareTransformedStrings(t *testing.T, str1, str2 string) bool {
 
 func compareJSONStrings(t *testing.T, str1, str2 string) bool {
 	// decode JSON
-	var m1,m2 interface{}
+	var m1, m2 interface{}
 	if err := json.Unmarshal([]byte(str1), &m1); err != nil {
 		t.Fatalf("Could not unmarshal JSON string: %s", str1)
 	}


### PR DESCRIPTION
There was a tiny mistake in the conversion of each export record from JSON to CSV format. Fixed that mistake and added a test to catch this moving forward.