### PR TITLE
Preserve case in CustomVars JSON doc

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -77,10 +77,10 @@ func TestTransformExportJSONRecord(t *testing.T) {
 			rec: map[string]interface{}{
 				"EventTargetText": "Heyo!",
 				"PageDuration":    42,
-				"custom_str":      "Heyo again!",
-				"custom_num":      42,
+				"myCustom_str":      "Heyo again!",
+				"myCustom_num":      42,
 			},
-			expResult: []string{"Heyo!", "42", `{"custom_str":"Heyo again!","custom_num":42}`},
+			expResult: []string{"Heyo!", "42", `{"myCustom_str":"Heyo again!","myCustom_num":42}`},
 		},
 		// missing column value for pageduration
 		{


### PR DESCRIPTION
In previous PRs, we added case-insensitive matching of columns in the target warehouse with values from the incoming export bundle's JSON document. When we did that, we failed to preserve the case of values in the CustomVars JSON document, which is important for any downstream ETL processes. For example, let's say we originally were producing CustomVars that looked like:

`{ "importantValue_str": "Important Data!!", "anImportantNum_real": 41 }`

With the bug, the keys in CustomVars became all lowercase: 

`{ "importantvalue_str": "Important Data!!", "animportantnum_real": 41 }`

This PR returns hauser to the state where case is preserved in CustomVars, while still doing case-insensitive matching to column names in the target warehouse.