### PR TITLE
staticcheck no longer supports Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ matrix:
     - go: tip
 
 script:
-  - if [[ "$VET" = 1 ]]; then make; else make deps test; fi
+  - if [[ "$VET" = 1 ]]; then make ci; else make deps test; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,19 @@ sudo: false
 
 matrix:
   include:
-    - go: "1.8"
-# TODO: stop supporting versions older than 1.9?
     - go: "1.9"
     - go: "1.10"
-      env: VET=1
     - go: "1.11"
+      env:
+      - GO111MODULE=off
+      - VET=1
+    - go: "1.11"
+      env: GO111MODULE=on
+    - go: "1.12"
       env: GO111MODULE=off
-    - go: "1.11"
+    - go: "1.12"
       env: GO111MODULE=on
     - go: tip
 
 script:
-  - if [[ "$VET" = 1 ]]; then make ci; else make test; fi
+  - if [[ "$VET" = 1 ]]; then make; else make deps test; fi

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ dev_build_version=$(shell git describe --tags --always --dirty)
 # to_check is all code in this repo that we want to run checks on
 # (it is all Go code in here, but intentionally excludes the
 # vendor folder contents)
-dirs_to_check=$(shell find . -maxdepth 1 -mindepth 1 -type d | grep -v .git | grep -v vendor)
+dirs_to_check=$(shell find . -maxdepth 1 -mindepth 1 -type d | grep -v .git | grep -v vendor | grep -v .images)
 files_to_check=$(shell find . -maxdepth 1 -mindepth 1 -type f -name '*.go')
 all_to_check=$(files_to_check) $(dirs_to_check)
 
@@ -12,7 +12,7 @@ all_to_check=$(files_to_check) $(dirs_to_check)
 # they are just too noisy to be a requirement for a CI -- we don't even *want*
 # to fix some of the things they consider to be violations.
 .PHONY: ci
-ci: install checkgofmt vet staticcheck unused ineffassign predeclared test
+ci: install checkgofmt vet staticcheck ineffassign predeclared test
 
 .PHONY: install
 install:
@@ -33,11 +33,6 @@ vet:
 staticcheck:
 	@go get honnef.co/go/tools/cmd/staticcheck
 	staticcheck ./...
-
-.PHONY: unused
-unused:
-	@go get honnef.co/go/tools/cmd/unused
-	unused ./...
 
 .PHONY: ineffassign
 ineffassign:

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,15 @@ all_to_check=$(files_to_check) $(dirs_to_check)
 # they are just too noisy to be a requirement for a CI -- we don't even *want*
 # to fix some of the things they consider to be violations.
 .PHONY: ci
-ci: install checkgofmt vet staticcheck ineffassign predeclared test
+ci: deps checkgofmt vet staticcheck ineffassign predeclared test
+
+.PHONY: deps
+deps:
+	go get -d -v -t ./...
+
+.PHONY: updatedeps
+updatedeps:
+	go get -d -v -t -u -f ./...
 
 .PHONY: install
 install:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 SQL recipes for Data Export analysis are in the [Data Export Cookbook](https://github.com/fullstorydev/hauser/wiki).
 
 ## Quick Start
-* Make sure you have [installed](https://golang.org/doc/install) Go 1.8 or higher.
+* Make sure you have [installed](https://golang.org/doc/install) Go 1.9 or higher.
 * Build it (for EC2, for example): ``GOOS=linux GOARCH=amd64 go get github.com/fullstorydev/hauser``
 * Copy the included `example-config.toml` file and customize it for your environment, including your FullStory API key, warehouse host, and credentials. AWS credentials (for S3) come from your local environment.
 * Run it: `./hauser -c <your updated config file>`


### PR DESCRIPTION
While changing the `.travis.yml` config, I also added builds for Go 1.12 and removes support for Go 1.8.

Also, I removed the `unused` check because that tool now reports itself as deprecated and superseded by `staticcheck`.

Finally, to make this consistent with other `fullstorydev` projects, I tweaked the build entry points in `.travis.yml` and modified the `Makefile` to follow suit.