### PR TITLE
Sam/json csv config

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To use the BigQuery warehouse, set the `Warehouse` config option to `bigquery`.
 
 By default, each export file is copied locally to the temp directory before it is moved to GCS. The GCS copy is then loaded into BigQuery through the gRPC client API equivalent of the `bq load` command.
 
-The BigQuery `ExportTable` is expected to be a date partitioned table. As with the `SyncTable`, if the `ExportTable` does not exist, it will be created on the fly, without an expiration time for the partitions. Finally, the GCS copy of the file is removed.
+The BigQuery `ExportTable` is expected to be a date partitioned table. The default values `ExportTable = "fs_export"` and `SyncTable = "fs_sync"` will work, but feel free to customize the `fs_sync` and `fs_export` names.  If the `SyncTable` and `ExportTable` do not already exist in BigQuery, they will be created on the fly, without an expiration time for the partitions. Once a file is loaded into BigQuery, the GCS copy of the file is removed.
 
 Loading data into BigQuery may be skipped by setting `GCS.GCSOnly` in the config file to `true`. In this mode, files are copied to GCS, where they remain without being loaded into BigQuery.
 

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	TmpDir          string
 	ListExportLimit int
 	GroupFilesByDay bool
+	SaveAsJson   bool
 
 	// for debug only; can point to localhost
 	ExportURL string
@@ -72,7 +73,6 @@ type LocalConfig struct {
 	SaveDir      string
 	StartTime    time.Time
 	UseStartTime bool
-	SaveAsJson   bool
 }
 
 func (d *duration) UnmarshalText(text []byte) error {

--- a/config/config.go
+++ b/config/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	TmpDir          string
 	ListExportLimit int
 	GroupFilesByDay bool
-	SaveAsJson   bool
+	SaveAsJson   	bool
 
 	// for debug only; can point to localhost
 	ExportURL string

--- a/example-config.toml
+++ b/example-config.toml
@@ -3,8 +3,9 @@ Backoff = "30s"
 BackoffStepsMax = 8
 CheckInterval = "30m"
 TmpDir = "/tmp"
-Warehouse="redshift"
+Warehouse="local"
 GroupFilesByDay = false
+SaveAsJson = false
 
 [s3]
 # bucket that will be used to stage files into Redshift
@@ -33,7 +34,8 @@ DatabaseSchema = "public"
 
 [gcs]
 Bucket = "<your bucket>"
-GCSOnly = false
+# upload data file only (i.e. skip load to BigQuery)?
+GCSOnly = true
 
 [bigquery]
 Project = "<your project>"
@@ -45,4 +47,4 @@ SyncTable = "<your sync table>"
 SaveDir = "<Path to your local folder to save files to>"
 StartTime = <Start time for data exports in the following format: 2018-12-27T18:30:00Z>
 UseStartTime = true
-SaveAsJson = true
+

--- a/example-config.toml
+++ b/example-config.toml
@@ -14,7 +14,7 @@ Bucket = ""
 Region = "us-east-2"
 # timeout for copying export files from the local machine to S3
 Timeout = "5m"
-# upload data file only (i.e. skip load to Redshift)?
+# upload data file only (i.e. skip load to Redshift)
 S3Only = true
 
 [redshift]
@@ -34,7 +34,7 @@ DatabaseSchema = "public"
 
 [gcs]
 Bucket = "<your bucket>"
-# upload data file only (i.e. skip load to BigQuery)?
+# upload data file only (i.e. skip load to Redshift)
 GCSOnly = true
 
 [bigquery]

--- a/example-config.toml
+++ b/example-config.toml
@@ -40,8 +40,8 @@ GCSOnly = true
 [bigquery]
 Project = "<your project>"
 Dataset = "<your dataset>"
-ExportTable = "<your export table>"
-SyncTable = "<your sync table>"
+ExportTable = "fs_export"
+SyncTable = "fs_sync"
 
 [local]
 SaveDir = "<Path to your local folder to save files to>"

--- a/example-config.toml
+++ b/example-config.toml
@@ -34,7 +34,7 @@ DatabaseSchema = "public"
 
 [gcs]
 Bucket = "<your bucket>"
-# upload data file only (i.e. skip load to Redshift)
+# upload data file only (i.e. skip load to BigQuery)
 GCSOnly = true
 
 [bigquery]

--- a/main.go
+++ b/main.go
@@ -111,7 +111,7 @@ func ProcessFilesIndividually(wh warehouse.Warehouse, tableColumns []string, fs 
 		mark := time.Now()
 		var filename string
 		var statusMessage string
-		if conf.Local.SaveAsJson {
+		if conf.SaveAsJson {
 			filename = filepath.Join(conf.TmpDir, fmt.Sprintf("%d.json", e.ID))
 			defer os.Remove(filename)
 			writtenCount, err := WriteBundleToJson(fs, e.ID, filename)
@@ -157,7 +157,7 @@ func ProcessFilesByDay(wh warehouse.Warehouse, tableColumns []string, fs *fullst
 	if len(exports) == 0 {
 		return 0, nil
 	}
-	if conf.Local.SaveAsJson {
+	if conf.SaveAsJson {
 		log.Fatalf("The option to process files by day is only supported for CSV format.")
 	}
 


### PR DESCRIPTION
SaveAsJson is now a global config variable.

Changed example-config.toml default settings to CSV format, local storage, and GCS only so that a user has more and easier paths to a valid config. 

Next step is adding checks and outputing appropriate error messages to the log so that the users can fix their config, but submitting this PR now to get quick fixes published while resolving some cloud credentialing issues.