### PR TITLE
Added checks for valid SaveAsJson, GCSOnly, and S3Only config combinations

### DIFF
--- a/main.go
+++ b/main.go
@@ -392,10 +392,17 @@ func main() {
 		wh = warehouse.NewLocalDisk(conf)
 	case "redshift":
 		wh = warehouse.NewRedshift(conf)
+		if conf.SaveAsJson {
+			if !conf.S3.S3Only {
+				log.Fatalf("Redshift doesn't support JSON format.  Ensure SaveAsJson = false in .toml file.")
+			}
+		}
 	case "bigquery":
 		wh = warehouse.NewBigQuery(conf)
 		if conf.SaveAsJson {
-			log.Fatalf("BigQuery doesn't support JSON format.  Ensure SaveAsJson = false in .toml file.")
+			if !conf.GCS.GCSOnly {
+				log.Fatalf("BigQuery doesn't support JSON format.  Ensure SaveAsJson = false in .toml file.")
+			}
 		}
 	default:
 		if len(conf.Warehouse) == 0 {

--- a/main.go
+++ b/main.go
@@ -394,6 +394,9 @@ func main() {
 		wh = warehouse.NewRedshift(conf)
 	case "bigquery":
 		wh = warehouse.NewBigQuery(conf)
+		if conf.SaveAsJson {
+			log.Fatalf("BigQuery doesn't support JSON format.  Ensure SaveAsJson = false in .toml file.")
+		}
 	default:
 		if len(conf.Warehouse) == 0 {
 			log.Fatal("Warehouse type must be specified in configuration")

--- a/main.go
+++ b/main.go
@@ -394,14 +394,14 @@ func main() {
 		wh = warehouse.NewRedshift(conf)
 		if conf.SaveAsJson {
 			if !conf.S3.S3Only {
-				log.Fatalf("Redshift doesn't support JSON format.  Ensure SaveAsJson = false in .toml file.")
+				log.Fatalf("Hauser doesn't currently support loading JSON into Redshift.  Ensure SaveAsJson = false in .toml file.")
 			}
 		}
 	case "bigquery":
 		wh = warehouse.NewBigQuery(conf)
 		if conf.SaveAsJson {
 			if !conf.GCS.GCSOnly {
-				log.Fatalf("BigQuery doesn't support JSON format.  Ensure SaveAsJson = false in .toml file.")
+				log.Fatalf("Hauser doesn't currently support loading JSON into BigQuery.  Ensure SaveAsJson = false in .toml file.")
 			}
 		}
 	default:


### PR DESCRIPTION
Added checks for valid SaveAsJson, GCSOnly, and S3Only config combinations.  

If an invalid config combination is detected, instructions for correcting it are printed to the terminal.