### PR TITLE
changed time precision to microseconds

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,10 +14,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/nishanths/fullstory"
-
 	"github.com/fullstorydev/hauser/config"
 	"github.com/fullstorydev/hauser/warehouse"
+	"github.com/nishanths/fullstory"
 	"github.com/pkg/errors"
 )
 

--- a/main_test.go
+++ b/main_test.go
@@ -160,7 +160,7 @@ func (sw *StubWarehouse) ValueToString(val interface{}, isTime bool) string {
 	s := fmt.Sprintf("%v", val)
 	if isTime {
 		t, _ := time.Parse(time.RFC3339Nano, s)
-		return t.Format(warehouse.RFC3339Milli)
+		return t.Format(warehouse.RFC3339Micro)
 	}
 	return s
 }

--- a/main_test.go
+++ b/main_test.go
@@ -160,7 +160,7 @@ func (sw *StubWarehouse) ValueToString(val interface{}, isTime bool) string {
 	s := fmt.Sprintf("%v", val)
 	if isTime {
 		t, _ := time.Parse(time.RFC3339Nano, s)
-		return t.Format(time.RFC3339)
+		return t.Format(warehouse.RFC3339Milli)
 	}
 	return s
 }

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -21,12 +21,16 @@ type Warehouse interface {
 	IsUploadOnly() bool
 }
 
+const (
+	RFC3339Milli = "2006-01-02T15:04:05.999999Z07:00"
+)
+
 // valueToString is a common interface method that implementations use to perform value to string conversion
 func valueToString(val interface{}, isTime bool) string {
 	s := fmt.Sprintf("%v", val)
 	if isTime {
 		t, _ := time.Parse(time.RFC3339Nano, s)
-		return t.Format("2006-01-02T15:04:05.999999Z07:00")
+		return t.Format(RFC3339Milli)
 	}
 
 	s = strings.Replace(s, "\n", " ", -1)

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -26,7 +26,7 @@ func valueToString(val interface{}, isTime bool) string {
 	s := fmt.Sprintf("%v", val)
 	if isTime {
 		t, _ := time.Parse(time.RFC3339Nano, s)
-		return t.Format(time.RFC3339)
+		return t.Format("2006-01-02T15:04:05.999999Z07:00")
 	}
 
 	s = strings.Replace(s, "\n", " ", -1)

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -21,9 +21,7 @@ type Warehouse interface {
 	IsUploadOnly() bool
 }
 
-const (
-	RFC3339Micro = "2006-01-02T15:04:05.999999Z07:00"
-)
+const RFC3339Micro = "2006-01-02T15:04:05.999999Z07:00"
 
 // valueToString is a common interface method that implementations use to perform value to string conversion
 func valueToString(val interface{}, isTime bool) string {

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -22,7 +22,7 @@ type Warehouse interface {
 }
 
 const (
-	RFC3339Milli = "2006-01-02T15:04:05.999999Z07:00"
+	RFC3339Micro = "2006-01-02T15:04:05.999999Z07:00"
 )
 
 // valueToString is a common interface method that implementations use to perform value to string conversion
@@ -30,7 +30,7 @@ func valueToString(val interface{}, isTime bool) string {
 	s := fmt.Sprintf("%v", val)
 	if isTime {
 		t, _ := time.Parse(time.RFC3339Nano, s)
-		return t.Format(RFC3339Milli)
+		return t.Format(RFC3339Micro)
 	}
 
 	s = strings.Replace(s, "\n", " ", -1)


### PR DESCRIPTION
The time-stamps that are extracted from the data export bundles are currently truncated to seconds. This change extends the precision to microseconds.