### PR TITLE
makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,31 +14,7 @@ all_to_check=$(files_to_check) $(dirs_to_check)
 .PHONY: ci
 ci: deps checkgofmt vet staticcheck ineffassign predeclared test
 
-BIN_DIR := $(GOPATH)/bin
-STATICCHECK := $(BIN_DIR)/staticcheck
-INEFFASSIGN := $(BIN_DIR)/ineffassign
-PREDECLARED := $(BIN_DIR)/predeclared
-GOLINT := $(BIN_DIR)/golint
-ERRCHECK := $(BIN_DIR)/errcheck
-
-INSTALLTOOL = cd /tmp && GO111MODULE=off go get -u
-
-# Installs the "staticcheck" tool outside of the current GOPATH
-$(STATICCHECK):
-	$(INSTALLTOOL) honnef.co/go/tools/cmd/staticcheck
-
-$(INEFFASSIGN):
-	$(INSTALLTOOL) github.com/gordonklaus/ineffassign
-
-$(PREDECLARED):
-	$(INSTALLTOOL) github.com/nishanths/predeclared
-
-$(GOLINT):
-	$(INSTALLTOOL) golang.org/x/lint/golint
-
-$(ERRCHECK):
-	$(INSTALLTOOL) github.com/kisielk/errcheck
-
+INSTALLTOOL = GO111MODULE=off go get
 
 .PHONY: deps
 deps:
@@ -64,25 +40,30 @@ vet:
 	go vet ./...
 
 .PHONY: staticcheck
-staticcheck: $(STATICCHECK)
+staticcheck:
+	$(INSTALLTOOL) honnef.co/go/tools/cmd/staticcheck
 	staticcheck ./...
 
 .PHONY: ineffassign
-ineffassign: $(INEFFASSIGN)
+ineffassign:
+	$(INSTALLTOOL) github.com/gordonklaus/ineffassign
 	ineffassign $(all_to_check)
 
 .PHONY: predeclared
-predeclared: $(PREDECLARED)
+predeclared:
+	$(INSTALLTOOL) github.com/nishanths/predeclared
 	predeclared $(all_to_check)
 
 # Intentionally omitted from CI, but target here for ad-hoc reports.
 .PHONY: golint
-golint: $(GOLINT)
+golint:
+	$(INSTALLTOOL) golang.org/x/lint/golint
 	golint -min_confidence 0.9 -set_exit_status . $(dirs_to_check)
 
 # Intentionally omitted from CI, but target here for ad-hoc reports.
 .PHONY: errcheck
-errcheck: $(ERRCHECK)
+errcheck:
+	$(INSTALLTOOL) github.com/kisielk/errcheck
 	errcheck ./...
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ dev_build_version=$(shell git describe --tags --always --dirty)
 # to_check is all code in this repo that we want to run checks on
 # (it is all Go code in here, but intentionally excludes the
 # vendor folder contents)
-dirs_to_check=./warehouse ./config
+dirs_to_check=$(shell find . -maxdepth 1 -mindepth 1 -type d | grep -vE '\./\.|vendor')
 files_to_check=$(shell find . -maxdepth 1 -mindepth 1 -type f -name '*.go')
 all_to_check=$(files_to_check) $(dirs_to_check)
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ dev_build_version=$(shell git describe --tags --always --dirty)
 # to_check is all code in this repo that we want to run checks on
 # (it is all Go code in here, but intentionally excludes the
 # vendor folder contents)
-dirs_to_check=$(shell find . -maxdepth 1 -mindepth 1 -type d | grep -v .git | grep -v vendor | grep -v .images)
+dirs_to_check=./warehouse ./config
 files_to_check=$(shell find . -maxdepth 1 -mindepth 1 -type f -name '*.go')
 all_to_check=$(files_to_check) $(dirs_to_check)
 
@@ -13,6 +13,32 @@ all_to_check=$(files_to_check) $(dirs_to_check)
 # to fix some of the things they consider to be violations.
 .PHONY: ci
 ci: deps checkgofmt vet staticcheck ineffassign predeclared test
+
+BIN_DIR := $(GOPATH)/bin
+STATICCHECK := $(BIN_DIR)/staticcheck
+INEFFASSIGN := $(BIN_DIR)/ineffassign
+PREDECLARED := $(BIN_DIR)/predeclared
+GOLINT := $(BIN_DIR)/golint
+ERRCHECK := $(BIN_DIR)/errcheck
+
+INSTALLTOOL = cd /tmp && GO111MODULE=off go get -u
+
+# Installs the "staticcheck" tool outside of the current GOPATH
+$(STATICCHECK):
+	$(INSTALLTOOL) honnef.co/go/tools/cmd/staticcheck
+
+$(INEFFASSIGN):
+	$(INSTALLTOOL) github.com/gordonklaus/ineffassign
+
+$(PREDECLARED):
+	$(INSTALLTOOL) github.com/nishanths/predeclared
+
+$(GOLINT):
+	$(INSTALLTOOL) golang.org/x/lint/golint
+
+$(ERRCHECK):
+	$(INSTALLTOOL) github.com/kisielk/errcheck
+
 
 .PHONY: deps
 deps:
@@ -38,30 +64,25 @@ vet:
 	go vet ./...
 
 .PHONY: staticcheck
-staticcheck:
-	@go get honnef.co/go/tools/cmd/staticcheck
+staticcheck: $(STATICCHECK)
 	staticcheck ./...
 
 .PHONY: ineffassign
-ineffassign:
-	@go get github.com/gordonklaus/ineffassign
+ineffassign: $(INEFFASSIGN)
 	ineffassign $(all_to_check)
 
 .PHONY: predeclared
-predeclared:
-	@go get github.com/nishanths/predeclared
+predeclared: $(PREDECLARED)
 	predeclared $(all_to_check)
 
 # Intentionally omitted from CI, but target here for ad-hoc reports.
 .PHONY: golint
-golint:
-	@go get golang.org/x/lint/golint
+golint: $(GOLINT)
 	golint -min_confidence 0.9 -set_exit_status . $(dirs_to_check)
 
 # Intentionally omitted from CI, but target here for ad-hoc reports.
 .PHONY: errcheck
-errcheck:
-	@go get github.com/kisielk/errcheck
+errcheck: $(ERRCHECK)
 	errcheck ./...
 
 .PHONY: test


### PR DESCRIPTION
I was running into trouble with installing the external code checking tools (staticcheck, etc.) when running `make`. This PR employs a fix where the directory is changed to a temporary directory before `go get -u` is called in order to avoid using the local `go.mod`.

Another benefit of the changes is that the tools are only fetched if they don't exist in `GOBIN`.

I also changed the `dirs_to_check` to be explicit because I was also having trouble with that picking up unwanted directories.