### PR TITLE
Temporarily remove module builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,8 @@ matrix:
       env:
       - GO111MODULE=off
       - VET=1
-    - go: "1.11"
-      env: GO111MODULE=on
     - go: "1.12"
       env: GO111MODULE=off
-    - go: "1.12"
-      env: GO111MODULE=on
     - go: tip
 
 script:


### PR DESCRIPTION
ASF mirror (git.apache.org) is experiencing [issues](https://status.apache.org/), and that is causing builds with modules enabled to fail.

This PR removes the two rows with module builds from the travis build matrix, so we can merge the [PR](https://github.com/fullstorydev/hauser/pull/69) which addresses some timezone issues with Redshift.