### PR TITLE
Allow S3 Only to use Sync Table

### DIFF
--- a/main.go
+++ b/main.go
@@ -210,6 +210,10 @@ func LoadBundles(wh warehouse.Warehouse, filename string, bundles ...fullstory.E
 	}
 
 	if wh.IsUploadOnly() {
+		if err := wh.SaveSyncPoints(bundles...); err != nil {
+			log.Printf("Failed to save sync points for bundles ending with %d: %s", bundles[len(bundles)].ID, err)
+			return err
+		}
 		return nil
 	}
 
@@ -228,6 +232,7 @@ func LoadBundles(wh warehouse.Warehouse, filename string, bundles ...fullstory.E
 		log.Printf("Failed to save sync points for bundles ending with %d: %s", bundles[len(bundles)].ID, err)
 		return err
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
Our use case had us only needing to ingest directly to S3.  In order to take advantage of hauser's Sync table feature, we needed to update this function to call SaveSyncPoints() when S3Only is set in the config.

A quick little hack here but this allows anyone who wants to use ONLY S3 to take advantage of the SyncTable.  This update will still preserve the intended functionality for Redshift warehouse users.

Hope others can find this useful.  