### PR TITLE
use go 1.13 to run vet tools; fix invocation of predeclared

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,20 @@ sudo: false
 
 matrix:
   include:
-    - go: "1.9"
-    - go: "1.10"
-    - go: "1.11"
-      env:
-      - GO111MODULE=off
-      - VET=1
-    - go: "1.11.4"
-      env: GO111MODULE=on
-    - go: "1.12"
+    - go: 1.11.x
       env: GO111MODULE=off
-    - go: "1.12"
+    - go: 1.12.x
+      env: GO111MODULE=off
+    - go: 1.12.x
+      env: GO111MODULE=on
+    - go: 1.13.x
+      env:
+      - GO111MODULE=on
+      - VET=1
+    - go: 1.14.x
       env: GO111MODULE=on
     - go: tip
+      env: GO111MODULE=on
 
 script:
   - if [[ "$VET" = 1 ]]; then make ci; else make deps test; fi

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ dirs_to_check=$(shell find . -maxdepth 1 -mindepth 1 -type d | grep -vE '\./\.|v
 files_to_check=$(shell find . -maxdepth 1 -mindepth 1 -type f -name '*.go')
 all_to_check=$(files_to_check) $(dirs_to_check)
 
+
 # TODO: run golint and errcheck, but only to catch *new* violations and
 # decide whether to change code or not (e.g. we need to be able to whitelist
 # violations already in the code). They can be useful to catch errors, but
@@ -52,7 +53,7 @@ ineffassign:
 .PHONY: predeclared
 predeclared:
 	$(INSTALLTOOL) github.com/nishanths/predeclared
-	predeclared $(all_to_check)
+	predeclared . $(dirs_to_check)
 
 # Intentionally omitted from CI, but target here for ad-hoc reports.
 .PHONY: golint


### PR DESCRIPTION
This should fix the [red build in CI](https://travis-ci.com/github/fullstorydev/hauser/builds/168322956).

With go 1.11, something happened recently that started causing compile errors in some of the CI checks. But switching to go 1.13 resolves them ¯\\_(ツ)\_/¯

While at it, I needed to change the args passed to `predeclared`. Strange that this didn't cause issues in previous CI checks, but I got errors when I tried to run it that it does not like to receive a mix of files and directories -- it either wants directory/package references or a list of files. It was previously getting a mix and then complaining that the directory names did not end in `.go`.