### PR TITLE
Apply auth headers in round tripper

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -49,7 +49,7 @@ var _ DataExportClient = (*Client)(nil)
 func NewClient(config *config.Config) *Client {
 	return &Client{
 		HTTPClient: &http.Client{
-			Transport: &FullStory{
+			Transport: &APIKeyRoundTripper{
 				Key:               config.FsApiToken,
 				AdditionalHeaders: config.AdditionalHttpHeader,
 			},

--- a/client/client.go
+++ b/client/client.go
@@ -48,8 +48,13 @@ var _ DataExportClient = (*Client)(nil)
 // supplied apiToken.
 func NewClient(config *config.Config) *Client {
 	return &Client{
-		HTTPClient: http.DefaultClient,
-		Config:     config,
+		HTTPClient: &http.Client{
+			Transport: &FullStory{
+				Key:               config.FsApiToken,
+				AdditionalHeaders: config.AdditionalHttpHeader,
+			},
+		},
+		Config: config,
 	}
 }
 
@@ -58,11 +63,6 @@ func NewClient(config *config.Config) *Client {
 //
 // If the error is nil, the caller is responsible for closing the returned data.
 func (c *Client) doReq(req *http.Request) (io.ReadCloser, error) {
-	req.Header.Set("Authorization", "Basic "+c.Config.FsApiToken)
-	for _, header := range c.Config.AdditionalHttpHeader {
-		req.Header.Set(header.Key, header.Value)
-	}
-
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err

--- a/client/transport.go
+++ b/client/transport.go
@@ -6,9 +6,9 @@ import (
 	"github.com/fullstorydev/hauser/config"
 )
 
-// FullStory is an HTTP transport which wraps the underlying transport and
+// APIKeyRoundTripper is an HTTP transport which wraps the underlying transport and
 // sets the Authorization header
-type FullStory struct {
+type APIKeyRoundTripper struct {
 	Key               string
 	AdditionalHeaders []config.Header
 
@@ -17,15 +17,14 @@ type FullStory struct {
 	Transport http.RoundTripper
 }
 
-func (t *FullStory) RoundTrip(req *http.Request) (*http.Response, error) {
+func (t *APIKeyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	rt := t.Transport
 	if rt == nil {
 		rt = http.DefaultTransport
 	}
-	newReq := *req
-	newReq.Header.Set("Authorization", "Basic "+t.Key)
+	req.Header.Set("Authorization", "Basic "+t.Key)
 	for _, header := range t.AdditionalHeaders {
-		newReq.Header.Set(header.Key, header.Value)
+		req.Header.Set(header.Key, header.Value)
 	}
-	return rt.RoundTrip(&newReq)
+	return rt.RoundTrip(req)
 }

--- a/client/transport.go
+++ b/client/transport.go
@@ -1,0 +1,31 @@
+package client
+
+import (
+	"net/http"
+
+	"github.com/fullstorydev/hauser/config"
+)
+
+// FullStory is an HTTP transport which wraps the underlying transport and
+// sets the Authorization header
+type FullStory struct {
+	Key               string
+	AdditionalHeaders []config.Header
+
+	// Transport is the underlying HTTP transport.
+	// if nil, http.DefaultTransport is used.
+	Transport http.RoundTripper
+}
+
+func (t *FullStory) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt := t.Transport
+	if rt == nil {
+		rt = http.DefaultTransport
+	}
+	newReq := *req
+	newReq.Header.Set("Authorization", "Basic "+t.Key)
+	for _, header := range t.AdditionalHeaders {
+		newReq.Header.Set(header.Key, header.Value)
+	}
+	return rt.RoundTrip(&newReq)
+}


### PR DESCRIPTION
Moves the API token and additional headers into
a round tripper implementation to remove it from
the `doReq` function.