### PR TITLE
Removed warehouse dependency on ExportMeta

### DIFF
--- a/internal/service.go
+++ b/internal/service.go
@@ -233,9 +233,9 @@ func (h *HauserService) LoadBundles(ctx context.Context, filename string, bundle
 		return fmt.Errorf("failed to save file: %s", err)
 	}
 
+	bundleEndTime := bundles[len(bundles)-1].Stop
 	if h.config.StorageOnly {
-
-		return h.storage.SaveSyncPoint(ctx, bundles[len(bundles)-1].Stop)
+		return h.storage.SaveSyncPoint(ctx, bundleEndTime)
 	}
 
 	defer h.storage.DeleteFile(ctx, objName)
@@ -250,7 +250,7 @@ func (h *HauserService) LoadBundles(ctx context.Context, filename string, bundle
 	// still okay - the next call to LastSyncPoint() will see that there are export
 	// records beyond the sync point and remove them - ie, we will reprocess the
 	// current export file
-	if err := h.database.SaveSyncPoint(ctx, bundles[len(bundles)-1].Stop); err != nil {
+	if err := h.database.SaveSyncPoint(ctx, bundleEndTime); err != nil {
 		log.Printf("Failed to save sync points for bundles ending with %d: %s", bundles[len(bundles)].ID, err)
 		return err
 	}

--- a/internal/service.go
+++ b/internal/service.go
@@ -234,12 +234,14 @@ func (h *HauserService) LoadBundles(ctx context.Context, filename string, bundle
 	}
 
 	if h.config.StorageOnly {
-		return h.storage.SaveSyncPoints(ctx, bundles...)
+
+		return h.storage.SaveSyncPoint(ctx, bundles[len(bundles)-1].Stop)
 	}
 
 	defer h.storage.DeleteFile(ctx, objName)
 
-	if err := h.database.LoadToWarehouse(objRef, bundles...); err != nil {
+	startTime := bundles[0].Start.UTC()
+	if err := h.database.LoadToWarehouse(objRef, startTime); err != nil {
 		log.Printf("Failed to load file '%s' to warehouse: %s", filename, err)
 		return err
 	}
@@ -248,7 +250,7 @@ func (h *HauserService) LoadBundles(ctx context.Context, filename string, bundle
 	// still okay - the next call to LastSyncPoint() will see that there are export
 	// records beyond the sync point and remove them - ie, we will reprocess the
 	// current export file
-	if err := h.database.SaveSyncPoints(ctx, bundles...); err != nil {
+	if err := h.database.SaveSyncPoint(ctx, bundles[len(bundles)-1].Stop); err != nil {
 		log.Printf("Failed to save sync points for bundles ending with %d: %s", bundles[len(bundles)].ID, err)
 		return err
 	}

--- a/testing/mockdatabase.go
+++ b/testing/mockdatabase.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/fullstorydev/hauser/client"
 	"github.com/fullstorydev/hauser/warehouse"
 )
 
@@ -20,7 +19,7 @@ var (
 type MockDatabase struct {
 	schema      warehouse.Schema
 	Initialized bool
-	Syncs       []client.ExportMeta
+	Syncs       []time.Time
 	LoadedFiles []string
 }
 
@@ -38,19 +37,19 @@ func NewMockDatabase() *MockDatabase {
 func (m *MockDatabase) LastSyncPoint(_ context.Context) (time.Time, error) {
 	var max time.Time
 	for i, s := range m.Syncs {
-		if i == 0 || s.Stop.After(max) {
-			max = s.Stop
+		if i == 0 || s.After(max) {
+			max = s
 		}
 	}
 	return max, nil
 }
 
-func (m *MockDatabase) SaveSyncPoints(_ context.Context, bundles ...client.ExportMeta) error {
-	m.Syncs = append(m.Syncs, bundles...)
+func (m *MockDatabase) SaveSyncPoint(_ context.Context, endTime time.Time) error {
+	m.Syncs = append(m.Syncs, endTime)
 	return nil
 }
 
-func (m *MockDatabase) LoadToWarehouse(filename string, _ ...client.ExportMeta) error {
+func (m *MockDatabase) LoadToWarehouse(filename string, _ time.Time) error {
 	m.LoadedFiles = append(m.LoadedFiles, filename)
 	return nil
 }

--- a/testing/mockstorage.go
+++ b/testing/mockstorage.go
@@ -8,12 +8,11 @@ import (
 	"io/ioutil"
 	"time"
 
-	"github.com/fullstorydev/hauser/client"
 	"github.com/fullstorydev/hauser/warehouse"
 )
 
 type MockStorage struct {
-	Syncs         []client.ExportMeta
+	Syncs         []time.Time
 	UploadedFiles map[string][]byte
 	DeletedFiles  []string
 }
@@ -31,15 +30,15 @@ func NewMockStorage() *MockStorage {
 func (m *MockStorage) LastSyncPoint(_ context.Context) (time.Time, error) {
 	var max time.Time
 	for i, s := range m.Syncs {
-		if i == 0 || s.Stop.After(max) {
-			max = s.Stop
+		if i == 0 || s.After(max) {
+			max = s
 		}
 	}
 	return max, nil
 }
 
-func (m *MockStorage) SaveSyncPoints(_ context.Context, bundles ...client.ExportMeta) error {
-	m.Syncs = append(m.Syncs, bundles...)
+func (m *MockStorage) SaveSyncPoint(ctx context.Context, endTime time.Time) error {
+	m.Syncs = append(m.Syncs, endTime)
 	return nil
 }
 

--- a/warehouse/gcs.go
+++ b/warehouse/gcs.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	"github.com/fullstorydev/hauser/client"
 	"github.com/fullstorydev/hauser/config"
 )
 
@@ -29,8 +28,8 @@ func (g *GCSStorage) LastSyncPoint(ctx context.Context) (time.Time, error) {
 	return SyncViaStorageMixin{g}.LastSyncPoint(ctx)
 }
 
-func (g *GCSStorage) SaveSyncPoints(ctx context.Context, bundles ...client.ExportMeta) error {
-	return SyncViaStorageMixin{g}.SaveSyncPoints(ctx, bundles...)
+func (g *GCSStorage) SaveSyncPoint(ctx context.Context, endTime time.Time) error {
+	return SyncViaStorageMixin{g}.SaveSyncPoint(ctx, endTime)
 }
 
 func (g *GCSStorage) SaveFile(ctx context.Context, name string, reader io.Reader) (string, error) {

--- a/warehouse/localdisk.go
+++ b/warehouse/localdisk.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/fullstorydev/hauser/client"
 	"github.com/fullstorydev/hauser/config"
 )
 
@@ -44,8 +43,8 @@ func (w *LocalDisk) LastSyncPoint(ctx context.Context) (time.Time, error) {
 	return SyncViaStorageMixin{w}.LastSyncPoint(ctx)
 }
 
-func (w *LocalDisk) SaveSyncPoints(ctx context.Context, bundles ...client.ExportMeta) error {
-	return SyncViaStorageMixin{w}.SaveSyncPoints(ctx, bundles...)
+func (w *LocalDisk) SaveSyncPoint(ctx context.Context, endTime time.Time) error {
+	return SyncViaStorageMixin{w}.SaveSyncPoint(ctx, endTime)
 }
 
 func (w *LocalDisk) SaveFile(_ context.Context, name string, reader io.Reader) (string, error) {

--- a/warehouse/s3.go
+++ b/warehouse/s3.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
-	"github.com/fullstorydev/hauser/client"
 	"github.com/fullstorydev/hauser/config"
 )
 
@@ -33,8 +32,8 @@ func (s *S3Storage) LastSyncPoint(ctx context.Context) (time.Time, error) {
 	return SyncViaStorageMixin{s}.LastSyncPoint(ctx)
 }
 
-func (s *S3Storage) SaveSyncPoints(ctx context.Context, bundles ...client.ExportMeta) error {
-	return SyncViaStorageMixin{s}.SaveSyncPoints(ctx, bundles...)
+func (s *S3Storage) SaveSyncPoint(ctx context.Context, endTime time.Time) error {
+	return SyncViaStorageMixin{s}.SaveSyncPoint(ctx, endTime)
 }
 
 func (s *S3Storage) SaveFile(ctx context.Context, name string, reader io.Reader) (string, error) {


### PR DESCRIPTION
To prep for using the new APIs, we need to remove the dependency on
`ExportMeta` from the warehouse package and instead rely directly
on the "stop time" (i.e. the time for the last bundle we loaded into
the warehouse). This change should be fairly transparent with the
exception of the ID that was inserted into the sync table.