### PR TITLE
Add FilePrefix to configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -52,6 +52,8 @@ type Config struct {
 
 	ApiURL string
 
+	FilePrefix string
+
 	// aws: s3 + redshift
 	S3       S3Config
 	Redshift RedshiftConfig

--- a/example-config.toml
+++ b/example-config.toml
@@ -31,6 +31,12 @@ Provider="local"
 StorageOnly = false
 SaveAsJson = false
 
+# FilePrefix can be used to specify a prefix for each of the files that are created.
+# For example, if using GCS or S3, you can use this setting to organizer your hauser uploads
+# into a "folder", such as "hauser-uploads/". In this case, the trailing slash is necessary
+# for GCS/S3 to recognize them as "folders".
+FilePrefix = ""
+
 # By default, these are not included since not every account has this feature.
 # IncludeMobileAppsFields = true
 

--- a/example-config.toml
+++ b/example-config.toml
@@ -32,7 +32,7 @@ StorageOnly = false
 SaveAsJson = false
 
 # FilePrefix can be used to specify a prefix for each of the files that are created.
-# For example, if using GCS or S3, you can use this setting to organizer your hauser uploads
+# For example, if using GCS or S3, you can use this setting to organize your hauser uploads
 # into a "folder", such as "hauser-uploads/". In this case, the trailing slash is necessary
 # for GCS/S3 to recognize them as "folders".
 FilePrefix = ""
@@ -81,4 +81,3 @@ PartitionExpiration = "0"
 SaveDir = "<Path to your local folder to save files to>"
 StartTime = <Start time for data exports in the following format: 2018-12-27T18:30:00Z>
 UseStartTime = true
-

--- a/warehouse/localdisk.go
+++ b/warehouse/localdisk.go
@@ -46,6 +46,9 @@ func (w *LocalDisk) SaveSyncPoint(ctx context.Context, endTime time.Time) error 
 
 func (w *LocalDisk) SaveFile(_ context.Context, name string, reader io.Reader) (string, error) {
 	filename := filepath.Join(w.conf.SaveDir, name)
+	if err := os.MkdirAll(filepath.Dir(filename), 0777); err != nil {
+		return "", err
+	}
 	f, err := os.Create(filename)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
This enables a "prefix" to be specified in the config file.
This configuration is especially useful if a user does not want
the files that hauser creates to be uploaded to the "root" folder
in cloud storage.