### PR TITLE
Fix FilePrefix when StorageOnly=true

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -71,7 +71,12 @@ type Header struct {
 	Value string
 }
 
+type StorageConfig struct {
+	FilePrefix string `toml:"-"`
+}
+
 type S3Config struct {
+	StorageConfig
 	Bucket  string
 	Region  string
 	Timeout Duration
@@ -94,6 +99,7 @@ type RedshiftConfig struct {
 }
 
 type GCSConfig struct {
+	StorageConfig
 	Bucket string
 	// Deprecated: Use `StorageOnly` option at the main level
 	GCSOnly bool
@@ -112,6 +118,7 @@ type Duration struct {
 }
 
 type LocalConfig struct {
+	StorageConfig
 	SaveDir string
 	// Deprecated: Use `StartTime` in the base config instead
 	StartTime time.Time
@@ -212,6 +219,7 @@ func Validate(conf *Config, getNow func() time.Time) error {
 		log.Println(`WARNING: The "local" provider only supports "StorageOnly = true".
           This value will be ignored in your configuration file.`)
 		conf.StorageOnly = true
+		conf.Local.FilePrefix = conf.FilePrefix
 	case AWSProvider:
 		conf.StorageOnly = conf.StorageOnly || conf.S3.S3Only
 
@@ -220,9 +228,11 @@ func Validate(conf *Config, getNow func() time.Time) error {
 			conf.Redshift.S3Region = conf.S3.Region
 		}
 		conf.S3.S3Only = false
+		conf.S3.FilePrefix = conf.FilePrefix
 	case GCProvider:
 		conf.StorageOnly = conf.StorageOnly || conf.GCS.GCSOnly
 		conf.GCS.GCSOnly = false
+		conf.GCS.FilePrefix = conf.FilePrefix
 	}
 	return nil
 }

--- a/testing/mockstorage.go
+++ b/testing/mockstorage.go
@@ -15,6 +15,7 @@ type MockStorage struct {
 	Syncs         []time.Time
 	UploadedFiles map[string][]byte
 	DeletedFiles  []string
+	FilePrefix    string
 }
 
 var _ warehouse.Storage = (*MockStorage)(nil)
@@ -24,6 +25,7 @@ func NewMockStorage() *MockStorage {
 		Syncs:         nil,
 		UploadedFiles: make(map[string][]byte),
 		DeletedFiles:  nil,
+		FilePrefix:    "prefix/",
 	}
 }
 
@@ -66,4 +68,8 @@ func (m *MockStorage) DeleteFile(_ context.Context, path string) error {
 
 func (m *MockStorage) GetFileReference(name string) string {
 	return fmt.Sprintf("mock://%s", name)
+}
+
+func (m *MockStorage) GetFilePrefix() string {
+	return m.FilePrefix
 }

--- a/warehouse/gcs.go
+++ b/warehouse/gcs.go
@@ -59,6 +59,10 @@ func (g *GCSStorage) GetFileReference(name string) string {
 	return fmt.Sprintf("gs://%s/%s", g.config.Bucket, name)
 }
 
+func (g *GCSStorage) GetFilePrefix() string {
+	return g.config.FilePrefix
+}
+
 func (g *GCSStorage) bucket() *storage.BucketHandle {
 	return g.gcsClient.Bucket(g.config.Bucket)
 }

--- a/warehouse/localdisk.go
+++ b/warehouse/localdisk.go
@@ -76,3 +76,7 @@ func (w *LocalDisk) ReadFile(_ context.Context, name string) (io.Reader, error) 
 func (w *LocalDisk) GetFileReference(name string) string {
 	return filepath.Join(w.conf.SaveDir, name)
 }
+
+func (w *LocalDisk) GetFilePrefix() string {
+	return w.conf.FilePrefix
+}

--- a/warehouse/s3.go
+++ b/warehouse/s3.go
@@ -91,6 +91,10 @@ func (s *S3Storage) GetFileReference(name string) string {
 	return fmt.Sprintf("s3://%s/%s", bucket, key)
 }
 
+func (s *S3Storage) GetFilePrefix() string {
+	return s.conf.FilePrefix
+}
+
 func (s *S3Storage) newSession() *session.Session {
 	return session.Must(session.NewSession(aws.NewConfig().WithRegion(s.conf.Region)))
 }


### PR DESCRIPTION
With the addition of #101, I missed that the
sync file that is created when `StorageOnly=true`
did not also receive the `FilePrefix` setting.