### PR TITLE
Dockerized hauser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM golang:1.13-alpine as builder
+MAINTAINER FullStory Engineering
+
+# create non-priveleged group and user
+RUN addgroup -S hauser && adduser -S hauser -G hauser
+
+WORKDIR /tmp/fullstorydev/hauser
+COPY VERSION *.go go.* /tmp/fullstorydev/hauser/
+COPY client /tmp/fullstorydev/hauser/client
+COPY config /tmp/fullstorydev/hauser/config
+COPY core /tmp/fullstorydev/hauser/core
+COPY internal /tmp/fullstorydev/hauser/internal
+COPY warehouse /tmp/fullstorydev/hauser/warehouse
+
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+ENV GOARCH=amd64
+ENV GO111MODULE=on
+RUN go build -o /hauser \
+    -ldflags "-w -extldflags \"-static\" -X \"main.version=$(cat VERSION)\"" \
+    .
+
+FROM scratch
+WORKDIR /
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /hauser /bin/hauser
+USER hauser
+
+ENTRYPOINT ["/bin/hauser"]

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ dev_build_version=$(shell git describe --tags --always --dirty)
 # to_check is all code in this repo that we want to run checks on
 # (it is all Go code in here, but intentionally excludes the
 # vendor folder contents)
-dirs_to_check=$(shell find . -maxdepth 1 -mindepth 1 -type d | grep -vE '\./\.|vendor|dist|recipes')
+dirs_to_check=$(shell find . -maxdepth 1 -mindepth 1 -type d | grep -vE '\./\.|vendor|dist|recipes|releasing')
 files_to_check=$(shell find . -maxdepth 1 -mindepth 1 -type f -name '*.go')
 all_to_check=$(files_to_check) $(dirs_to_check)
 
@@ -33,6 +33,12 @@ install:
 release:
 	$(INSTALLTOOL) github.com/goreleaser/goreleaser
 	goreleaser --rm-dist
+
+.PHONY: docker
+docker:
+	@echo $(dev_build_version) > VERSION
+	docker build -t fullstorydev/hauser:$(dev_build_version) .
+	@rm VERSION
 
 .PHONY: checkgofmt
 checkgofmt:

--- a/releasing/README.md
+++ b/releasing/README.md
@@ -1,0 +1,68 @@
+# Releases of hauser
+
+This document provides instructions for building a release of `hauser`.
+
+The release process consists of a handful of tasks:
+1. Drop a release tag in git.
+2. Build binaries for various platforms. This is done using the local `go` tool and uses `GOOS` and `GOARCH` environment variables to cross-compile for supported platforms.
+3. Creates a release in GitHub, uploads the binaries, and creates provisional release notes (in the form of a change log).
+4. Build a docker image for the new release.
+5. Push the docker image to Docker Hub, with both a version tag and the "latest" tag.
+
+Most of this is automated via a script in this same directory. The main thing you will need is a GitHub personal access token, which will be used for creating the release in GitHub (so you need write access to the fullstorydev/hauser repo).
+
+## Creating a new release
+
+So, to actually create a new release, just run the script in this directory.
+
+First, you need a version number for the new release, following sem-ver format: `v<Major>.<Minor>.<Patch>`. Second, you need a personal access token for GitHub.
+
+We'll use `v2.3.4` as an example version and `abcdef0123456789abcdef` as an example GitHub token:
+
+```sh
+# from the root of the repo
+GITHUB_TOKEN=abcdef0123456789abcd \
+    ./releasing/do-release.sh v2.3.4
+```
+
+Wasn't that easy! There is one last step: update the release notes in GitHub. By default, the script just records a change log of commit descriptions. Use that log (and, if necessary, drill into individual PRs included in the release) to flesh out notes in the format of the `RELEASE_NOTES.md` file _in this directory_. Then login to GitHub, go to the new release, edit the notes, and paste in the markdown you just wrote.
+
+That should be all there is to it! If things go wrong and you have to re-do part of the process, see the sections below.
+
+----
+
+### GitHub Releases
+The GitHub release is the first step performed by the `do-release.sh` script. So generally, if there is an issue with that step, you can re-try the whole script.
+
+Note, if running the script did something wrong, you may have to first login to GitHub and remove uploaded artifacts for a botched release attempt. In general, this is _very undesirable_. Releases should usually be considered immutable. Instead of removing uploaded assets and providing new ones, it is often better to remove uploaded assets (to make bad binaries no longer available) and then _release a new patch version_. (You can edit the release notes for the botched version explaining why there are no artifacts for it.)
+
+The steps to do a GitHub-only release (vs. running the entire script) are the following:
+
+```sh
+# from the root of the repo
+git tag v2.3.4
+GITHUB_TOKEN=abcdef0123456789abcdef \
+    GO111MODULE=on \
+    make release
+```
+
+The `git tag ...` step is necessary because the release target requires that the current SHA have a sem-ver tag. That's the version it will use when creating the release.
+
+This will create the release in GitHub with provisional release notes that just include a change log of commit messages. You still need to login to GitHub and revise those notes to adhere to the recommended format. (See `RELEASE_NOTES.md` in this directory.)
+
+### Docker Hub Releases
+
+To re-run only the Docker Hub release steps, we need to build an image with the right tag and then push to Docker Hub.
+
+```sh
+# from the root of the repo
+echo v2.3.4 > VERSION
+docker build -t fullstorydev/hauser:v2.3.4 .
+# now that we have it built, push to Docker Hub
+docker push fullstorydev/hauser:v2.3.4
+# push "latest" tag, too
+docker tag fullstorydev/hauser:v2.3.4 fullstorydev/hauser:latest
+docker push fullstorydev/hauser:latest
+```
+
+If the `docker push ...` steps fail, you may need to run `docker login`, enter your Docker Hub login credentials, and then try to push again.

--- a/releasing/do-release.sh
+++ b/releasing/do-release.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# strict mode
+set -euo pipefail
+IFS=$'\n\t'
+
+if [[ -z ${DRY_RUN:-} ]]; then
+    PREFIX=""
+else
+    PREFIX="echo"
+fi
+
+# input validation
+if [[ -z ${GITHUB_TOKEN:-} ]]; then
+    echo "GITHUB_TOKEN environment variable must be set before running." >&2
+    exit 1
+fi
+if [[ $# -ne 1 || $1 == "" ]]; then
+    echo "This program requires one argument: the version number, in 'vM.N.P' format." >&2
+    exit 1
+fi
+VERSION=$1
+
+# Change to root of the repo
+cd "$(dirname "$0")/.."
+
+# GitHub release
+
+$PREFIX git tag "$VERSION"
+# make sure GITHUB_TOKEN is exported, for the benefit of this next command
+export GITHUB_TOKEN
+#GO111MODULE=on $PREFIX make release
+# if that was successful, it could have touched go.mod and go.sum, so revert those
+$PREFIX git checkout go.mod go.sum
+
+# Docker release
+
+# make sure credentials are valid for later push steps; this might
+# be interactive since this will prompt for username and password
+# if there are no valid current credentials.
+$PREFIX docker login
+echo "$VERSION" > VERSION
+$PREFIX docker build -t "fullstorydev/hauser:${VERSION}" .
+rm VERSION
+# push to docker hub, both the given version as a tag and for "latest" tag
+$PREFIX docker push "fullstorydev/hauser:${VERSION}"
+$PREFIX docker tag "fullstorydev/hauser:${VERSION}" fullstorydev/hauser:latest
+$PREFIX docker push fullstorydev/hauser:latest


### PR DESCRIPTION
Add a dockerfile that can be used to build
a minimal docker image. Also adds a script for
releasing based on the pattern established in
[grpcurl](https://github.com/fullstorydev/grpcurl) that
makes the release and pushes a docker image.