### PR TITLE
Fix folder permissions in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,9 @@ RUN go build -o /hauser \
     -ldflags "-w -extldflags \"-static\" -X \"main.version=$(cat VERSION)\"" \
     .
 
-FROM scratch
-WORKDIR /
+FROM alpine:3.13.5
+WORKDIR /hauser
+RUN addgroup -S hauser && adduser -S hauser -G hauser && chown -R hauser:hauser /hauser
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /hauser /bin/hauser

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.13-alpine as builder
 MAINTAINER FullStory Engineering
 
-# create non-priveleged group and user and an owned directory
+# create non-privileged group and user and an owned directory
 RUN addgroup -S hauser && adduser -S hauser -G hauser && \
  mkdir /hauser && chown -R hauser:hauser /hauser
 

--- a/README.md
+++ b/README.md
@@ -116,12 +116,33 @@ FROM myexport
 WHERE JSON_EXTRACT_PATH_TEXT(CustomVars, 'acct_adminDisabled_bool') = 'false';
 ```
 
-## Dockerizing Hauser
-A minimal docker image can be found on docker hub at https://hub.docker.com/r/fullstorydev/hauser
+## Using hauser with Docker
+For platforms that support Docker, you can download an image from [docker hub](https://hub.docker.com/r/fullstorydev/hauser) that lets you run `hauser`:
 
-Alternatively, to include the prebuilt Hauser binary in a Docker container, add the following to your Dockerfile.
-Note that the example below assumes the base image is linux.
+```shell
+# Download image
+docker pull fullstorydev/hauser:latest
 
+# Assumes that your config.toml is in the current directory
+docker run --rm \
+  -v $(pwd)/config.toml:/config.toml \
+  fullstorydev/hauser:latest -c /config.toml
+```
+
+To include Hauser in a custom Docker container, add the following to your Dockerfile.
+Note that the example below assumes the desired image is linux.
+
+```Dockerfile
+FROM fullstorydev/hauser:latest as builder
+
+# Custom docker config ...
+FROM alpine:latest
+COPY --from=builder /bin/hauser /usr/bin/hauser
+
+# Entry point ...
+```
+
+Or you can download the release directly:
 ```Dockerfile
 RUN curl -L >hauser.tar.gz https://github.com/fullstorydev/hauser/releases/download/v${HAUSER_VERSION}/hauser_${HAUSER_VERSION}_linux_x86_64.tar.gz \
   && tar -xzvf hauser.tar.gz -C /usr/bin \

--- a/example-config.toml
+++ b/example-config.toml
@@ -4,7 +4,7 @@ BackoffStepsMax = 8
 
 # TmpDir is a directory where the exported files are downloaded to before they are uploaded
 # to the warehouse destination. The hauser process will remove these files when it has finished
-# processing it.
+# processing them.
 TmpDir = "tmp"
 
 # ExportDuration determines the time range for each export bundle. The max value is 24 hours.

--- a/example-config.toml
+++ b/example-config.toml
@@ -1,7 +1,11 @@
 FsApiToken = "<your FullStory API token>"
 Backoff = "30s"
 BackoffStepsMax = 8
-TmpDir = "/tmp"
+
+# TmpDir is a directory where the exported files are downloaded to before they are uploaded
+# to the warehouse destination. The hauser process will remove these files when it has finished
+# processing it.
+TmpDir = "tmp"
 
 # ExportDuration determines the time range for each export bundle. The max value is 24 hours.
 # If downloads are not completing due to timeouts, lower this value until the downloads


### PR DESCRIPTION
There was an issue with using the scratch
image because hauser expects to be able to create
directories for temporary files. With the scratch
image, the `hauser` user did not have permission to
create the directory, so the process would fail.
Use `--chown` flag when copying over the directory
to ensure the `hauser` user can write to it.