### PR TITLE
Add options to modify client

### DIFF
--- a/client/export.go
+++ b/client/export.go
@@ -71,6 +71,11 @@ func (c *Client) CreateExport(start time.Time, end time.Time, fields []string) (
 	if err != nil {
 		return "", err
 	}
+
+	if c.createRequestModifier != nil {
+		c.createRequestModifier(req)
+	}
+
 	resBody, err := c.doReq(req)
 	if err != nil {
 		// Status 429, 499, 500 -- retry


### PR DESCRIPTION
When used as a library, it can be useful to modify
how the client operates. This change adds the ability
to modify the client using the "options" pattern.
The two new options are:
* WithHttpClient - for modifying the underlying http transport
* WithCreateExportRequestModifier - for modifying the "CreateExport"
  API request before sending.