### PR TITLE
Allow SaveAsJson=true when StorageOnly=true

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -209,10 +209,6 @@ func Validate(conf *Config, getNow func() time.Time) error {
 		conf.Warehouse = ""
 	}
 
-	if conf.SaveAsJson && conf.Provider != "local" {
-		return fmt.Errorf("hauser doesn't currently support loading JSON into a database. Ensure SaveAsJson = false in .toml file")
-	}
-
 	switch conf.Provider {
 	case LocalProvider:
 		// The local provider only supports storage
@@ -233,6 +229,10 @@ func Validate(conf *Config, getNow func() time.Time) error {
 		conf.StorageOnly = conf.StorageOnly || conf.GCS.GCSOnly
 		conf.GCS.GCSOnly = false
 		conf.GCS.FilePrefix = conf.FilePrefix
+	}
+
+	if conf.SaveAsJson && !(conf.Provider == "local" || conf.StorageOnly) {
+		return fmt.Errorf("hauser doesn't currently support loading JSON into a database. Ensure SaveAsJson = false in .toml file")
 	}
 	return nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -140,7 +140,8 @@ func TestValidate(t *testing.T) {
 		{
 			name: "gcp backwards compat, storage only",
 			conf: &Config{
-				Warehouse: "bigquery",
+				Warehouse:  "bigquery",
+				SaveAsJson: true,
 				GCS: GCSConfig{
 					Bucket:  "bucket",
 					GCSOnly: true,
@@ -149,6 +150,7 @@ func TestValidate(t *testing.T) {
 			expected: &Config{
 				Provider:       "gcp",
 				StorageOnly:    true,
+				SaveAsJson:     true,
 				ApiURL:         DefaultApiURL,
 				ExportDuration: Duration{time.Hour},
 				ExportDelay:    Duration{24 * time.Hour},


### PR DESCRIPTION
There is currently a requirement that `SaveAsJson`
is only available if the provider is local. This
should be available for all providers assuming
`StorageOnly=true`.