### PR TITLE
feat: fetch api token from env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ SQL recipes for Data Export analysis are in the [Data Export Cookbook](https://g
 
 ### Important Configuration Fields
 
+#### `FsApiToken`
+Your FullStory API Token. It can also be set through the `FULLSTORY_API_TOKEN` environment variable.
+
 #### `ExportDuration`
 Determines the time range for each export which ultimately determines the size of each exported file.
 The size of this file will be based on the amount of traffic that your FullStory account records within the

--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"os"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -143,6 +144,10 @@ func Load(filename string) (*Config, error) {
 
 	if _, err := toml.Decode(string(tomlData), &conf); err != nil {
 		return nil, err
+	}
+
+	if envToken := os.Getenv("FULLSTORY_API_TOKEN"); envToken != "" {
+		conf.FsApiToken = envToken
 	}
 
 	if err := Validate(&conf, time.Now); err != nil {


### PR DESCRIPTION
avoid having to hardcode the api token in the config file by overriding it with the `FULLSTORY_API_TOKEN` environment variable