### PR TITLE
Fix missing types in schema

### DIFF
--- a/warehouse/bigquery.go
+++ b/warehouse/bigquery.go
@@ -17,6 +17,8 @@ var (
 		reflect.TypeOf(int64(0)):    bigquery.IntegerFieldType,
 		reflect.TypeOf(""):          bigquery.StringFieldType,
 		reflect.TypeOf(time.Time{}): bigquery.TimestampFieldType,
+		reflect.TypeOf(float64(0)):  bigquery.FloatFieldType,
+		reflect.TypeOf(int32(0)):    bigquery.IntegerFieldType,
 	}
 )
 

--- a/warehouse/bigquery_test.go
+++ b/warehouse/bigquery_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/bigquery"
+	"github.com/fullstorydev/hauser/testing/testutils"
 )
 
 func TestGetMissingFields(t *testing.T) {
@@ -74,5 +75,13 @@ func TestGetMissingFields(t *testing.T) {
 		if got := wh.GetMissingFields(testCase.hauserSchema, testCase.tableSchema); len(got) != testCase.missingFields {
 			t.Errorf("Expected %d missing fields, got %d", testCase.missingFields, len(got))
 		}
+	}
+}
+
+func TestBigquerySchema(t *testing.T) {
+	fs := MakeSchema(BaseExportFields{}, MobileFields{})
+	for _, field := range fs {
+		_, ok := bigQueryTypeMap[field.FieldType]
+		testutils.Assert(t, ok, "field type %v not found in bigQueryTypeMap", field.FieldType)
 	}
 }

--- a/warehouse/redshift.go
+++ b/warehouse/redshift.go
@@ -25,6 +25,8 @@ var (
 		reflect.TypeOf(int64(0)):    "BIGINT",
 		reflect.TypeOf(""):          "VARCHAR(max)",
 		reflect.TypeOf(time.Time{}): "TIMESTAMP",
+		reflect.TypeOf(float64(0)):  "FLOAT",
+		reflect.TypeOf(int32(0)):    "INTEGER",
 	}
 )
 

--- a/warehouse/redshift_test.go
+++ b/warehouse/redshift_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/fullstorydev/hauser/config"
+	"github.com/fullstorydev/hauser/testing/testutils"
 )
 
 func makeConf(databaseSchema string) *config.RedshiftConfig {
@@ -12,6 +13,14 @@ func makeConf(databaseSchema string) *config.RedshiftConfig {
 		VarCharMax:     20,
 		ExportTable:    "exportTable",
 		SyncTable:      "syncTable",
+	}
+}
+
+func TestRedshiftSchema(t *testing.T) {
+	fs := MakeSchema(BaseExportFields{}, MobileFields{})
+	for _, field := range fs {
+		_, ok := redshiftSchemaMap[field.FieldType]
+		testutils.Assert(t, ok, "field type %v not found in redshiftSchemaMap", field.FieldType)
 	}
 }
 


### PR DESCRIPTION
The new fields that were added for the most recent major version included new types. There were no tests to cover the mapping when creating the schema for the warehouses, so this was missed.

Add the new type mappings in and tests to make sure this doesn't happen again.